### PR TITLE
@W-14093602@: Implements OpenVSX publishing pipeline

### DIFF
--- a/.github/workflows/openvsx-initial-release.yml
+++ b/.github/workflows/openvsx-initial-release.yml
@@ -1,0 +1,35 @@
+name: Publish v0.2.0 to OpenVSX marketplace
+on:
+  # Should only be possible to run this action manually.
+  workflow_dispatch:
+
+jobs:
+  publish-openvsx:
+    name: 'Publish to OpenVSX marketplace'
+    # The `publish` environment is inherited from the org level, and means the job
+    # can't proceed until someone with appropriate permissions approves it.
+    environment: publish
+    runs-on: ubuntu-latest
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@v3
+        with:
+          ref: 'v0.2.0'
+          token: ${{ env.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - run: yarn install --frozen-lockfile
+      - name: Download Extension from Release
+        run: |
+          mkdir ./extensions
+          gh release download v0.2.0 -D ./extensions
+      - name: Display downloaded VSIX
+        run: ls -R ./extensions
+      - name: Publish the VSIX
+        run: find ./extensions -type f -name "*.vsix" -exec npx ovsx publish {} -p ${{ env.OVSX_PAT}} \;
+      - run: echo "SUCCESSFULLY PUBLISHED"
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish in Microsoft Marketplace
+name: Publish Extension
 on:
   release:
     # This limits the workflow to releases that are not pre-releases.
@@ -15,29 +15,27 @@ on:
 jobs:
   validate-release-environment:
     runs-on: ubuntu-latest
+    # The `publish` environment is inherited from the org level, and means the job
+    # can't proceed until someone with appropriate permissions approves it.
     environment: publish
-    outputs:
-      RELEASE_VERSION: ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
-      GUS_BUILD: ${{ steps.get-gus-build.outputs.GUS_BUILD }}
-      SF_CHANGE_CASE_SCHEDULE_BUILD: ${{ steps.get-scheduled-build.outputs.SF_CHANGE_CASE_SCHEDULE_BUILD }}
     steps:
-      # Check out the release branch and get its head commit as output for later.
+      # Check out the main branch and get its head commit as output for later.
       - uses: actions/checkout@v3
         with:
           ref: 'main'
-      - id: get-branch-commit
+      - id: get-main-head
         run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       # Check out the tag to be released and get its head commit as output for later.
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
-      - id: get-tag-commit
+      - id: get-tag-head
         run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       # If the two commits aren't identical, the tag isn't eligible for release.
       - name: Fail non-matching commits
-        if: ${{ steps.get-branch-commit.outputs.COMMIT_ID != steps.get-tag-commit.outputs.COMMIT_ID }}
+        if: ${{ steps.get-main-head.outputs.COMMIT_ID != steps.get-tag-head.outputs.COMMIT_ID }}
         run: |
-          echo "Tag commit must match latest commit in main. Branch is ${{ steps.get-branch-commit.outputs.COMMIT_ID }}. Tag is ${{ steps.get-tag-commit.outputs.COMMIT_ID }}."
+          echo "Tag commit must match latest commit in main branch. Branch head is ${{ steps.get-main-head.outputs.COMMIT_ID }}. Tag head is ${{ steps.get-tag-head.outputs.COMMIT_ID }}."
           exit 1
       # Get the `version` property from `package.json` as output for later.
       - name: Get package.json version property
@@ -52,12 +50,6 @@ jobs:
           PACKAGE_VERSION=v${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
           [[ ${TAG} == ${PACKAGE_VERSION} ]] || (echo "Tag name must match package.json version, prefixed by lowercase v" && exit 1)
       # Set other miscellaneous environment variables as outputs for later.
-      - id: get-gus-build
-        run: echo "GUS_BUILD=${{ steps.get-package-version.outputs.PACKAGE_VERSION }}" >> $GITHUB_OUTPUT
-      - run: echo "GUS BUILD IS ${{ steps.get-gus-build.outputs.GUS_BUILD }}"
-      - id: get-scheduled-build
-        run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD=offcore.tooling.${{ steps.get-package-version.outputs.PACKAGE_VERSION }}" > $GITHUB_OUTPUT
-      - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.get-scheduled-build.outputs.SF_CHANGE_CASE_SCHEDULE_BUILD }}"
 
   run-tests:
     name: 'Test against production scanner'
@@ -68,7 +60,8 @@ jobs:
       # version of the scanner is currently live.
       use-scanner-tarball: false
 
-  publish:
+  publish-vscode:
+    name: 'Publish to VSCode Marketplace'
     needs: [ 'run-tests' ]
     runs-on: ubuntu-latest
     env:
@@ -95,4 +88,34 @@ jobs:
       - name: Publish the VSIX
         run: find ./extensions -type f -name "*.vsix" -exec npx vsce publish --pat ${{ env.VSCE_PERSONAL_ACCESS_TOKEN }} --packagePath {} \;
       - run: echo "SUCCESSFULLY PUBLISHED"
+
+  publish-openvsx:
+    name: 'Publish to OpenVSX marketplace'
+    needs: [ 'run-tests' ]
+    runs-on: ubuntu-latest
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          token: ${{ env.GITHUB_TOKEN }}
+      # Set up node and install dependencies.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - run: yarn install --frozen-lockfile
+      # Download the .vsix attached to the release.
+      - name: Download Extension From Release
+        run: |
+          mkdir ./extensions
+          gh release download ${{ github.event.release.tag_name || inputs.tag }} -D ./extensions
+      - name: Display downloaded VSIX
+        run: ls -R ./extensions
+      - name: Publish the VSIX
+        run: find ./extensions -type f -name "*.vsix" -exec osvx publish {} -p ${{ env.OSVX_PAT }} \;
+      - run: echo "SUCCESSFULLY PUBLISHED"
+
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Display downloaded VSIX
         run: ls -R ./extensions
       - name: Publish the VSIX
-        run: find ./extensions -type f -name "*.vsix" -exec osvx publish {} -p ${{ env.OSVX_PAT }} \;
+        run: find ./extensions -type f -name "*.vsix" -exec npx osvx publish {} -p ${{ env.OSVX_PAT }} \;
       - run: echo "SUCCESSFULLY PUBLISHED"
 
 

--- a/package.json
+++ b/package.json
@@ -49,11 +49,12 @@
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "@vscode/test-electron": "^2.2.0",
-		"@vscode/vsce": "^2.20.0",
+        "@vscode/vsce": "^2.20.0",
         "chai": "^4.3.7",
         "eslint": "^8.28.0",
         "mocha": "^10.1.0",
         "nyc": "^15.1.0",
+        "ovsx": "^0.8.3",
         "sinon": "^15.1.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,6 +557,34 @@
     jszip "^3.10.1"
     semver "^7.5.2"
 
+"@vscode/vsce@^2.19.0":
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.21.1.tgz#793c78d992483b428611a3927211a9640041be14"
+  integrity sha512-f45/aT+HTubfCU2oC7IaWnH9NjOWp668ML002QiFObFRVUCoLtcwepp9mmql/ArFUy+HCHp54Xrq4koTcOD6TA==
+  dependencies:
+    azure-devops-node-api "^11.0.1"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.9"
+    commander "^6.2.1"
+    glob "^7.0.6"
+    hosted-git-info "^4.0.2"
+    jsonc-parser "^3.2.0"
+    leven "^3.1.0"
+    markdown-it "^12.3.2"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^7.5.2"
+    tmp "^0.2.1"
+    typed-rest-client "^1.8.4"
+    url-join "^4.0.1"
+    xml2js "^0.5.0"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+  optionalDependencies:
+    keytar "^7.7.0"
+
 "@vscode/vsce@^2.20.0":
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.21.0.tgz#572e66db79cff383b9ac39f71710aa62e6392330"
@@ -901,6 +929,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -948,7 +981,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -1372,6 +1405,11 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.14.6:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
@@ -1659,6 +1697,13 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -2206,6 +2251,19 @@ optionator@^0.9.3:
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
+
+ovsx@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.8.3.tgz#3c67a595e423f3f70a3d62da3735dd07dfbca69f"
+  integrity sha512-LG7wTzy4eYV/KolFeO4AwWPzQSARvCONzd5oHQlNvYOlji2r/zjbdK8pyObZN84uZlk6rQBWrJrAdJfh/SX0Hg==
+  dependencies:
+    "@vscode/vsce" "^2.19.0"
+    commander "^6.1.0"
+    follow-redirects "^1.14.6"
+    is-ci "^2.0.0"
+    leven "^3.1.0"
+    semver "^7.5.2"
+    tmp "^0.2.1"
 
 p-limit@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
This PR adds the following:
- A publishing pipeline for OpenVSX that runs alongside the existing VSCode pipeline, publishing the releases in tandem.
- A pipeline specifically for publishing v0.2.0 to OpenVSX specifically, which we can use for the initial release and then never touch again.