### PR TITLE
@W-14573340@: Fixed errors in publish script.

### DIFF
--- a/.github/workflows/openvsx-0-3-0-release.yml
+++ b/.github/workflows/openvsx-0-3-0-release.yml
@@ -1,4 +1,4 @@
-name: Publish v0.2.0 to OpenVSX marketplace
+name: Publish v0.3.0 to OpenVSX marketplace
 on:
   # Should only be possible to run this action manually.
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
       - name: Check out the release tag
         uses: actions/checkout@v3
         with:
-          ref: 'v0.2.0'
+          ref: 'v0.3.0'
           token: ${{ env.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
@@ -26,7 +26,7 @@ jobs:
       - name: Download Extension from Release
         run: |
           mkdir ./extensions
-          gh release download v0.2.0 -D ./extensions
+          gh release download v0.3.0 -D ./extensions
       - name: Display downloaded VSIX
         run: ls -R ./extensions
       - name: Publish the VSIX

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Display downloaded VSIX
         run: ls -R ./extensions
       - name: Publish the VSIX
-        run: find ./extensions -type f -name "*.vsix" -exec npx osvx publish {} -p ${{ env.IDEE_OVSX_PAT }} \;
+        run: find ./extensions -type f -name "*.vsix" -exec npx ovsx publish {} -p ${{ env.IDEE_OVSX_PAT }} \;
       - run: echo "SUCCESSFULLY PUBLISHED"
 
 


### PR DESCRIPTION
This PR does the following:
- Corrects a typo in the publish script (`osvx` should have been `ovsx`)
- Converts the v0.2.0-only OpenVSX release script into one that can release v0.3.0, so we don't have to publish a v0.3.1. (Context: the typo prevented the v0.3.0 release from succeeding on OpenVSX only.)