### PR TITLE
FIX(Extension): @W-15253475@: Fix the errors displayed when there are no violations

### DIFF
--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -39,7 +39,7 @@ export class ScanRunner {
         const executionResult: AnyJson = await this.invokeAnalyzer(args, false);
 
         // Process the results.
-        return executionResult as RuleResult[];
+        return this.processResults(executionResult);
     }
 
     /**
@@ -144,5 +144,13 @@ export class ScanRunner {
             await runAction.validateInputs(args);
             return runAction.run(args);
         }
+    }
+
+    private processResults(results: AnyJson): RuleResult[] {
+        const ruleResult = results as string;
+        if (ruleResult.includes('No rule violations found.')) {
+            return [];
+        }
+        return results as RuleResult[];
     }
 }

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -146,11 +146,21 @@ export class ScanRunner {
         }
     }
 
+    /**
+     * Processes results from runAction. The results is in the RuleResult format when there are violations.
+     * Where there are no violations, it is in string format.
+     * @param results in AnyJson format
+     * @returns 
+     */
     private processResults(results: AnyJson): RuleResult[] {
-        const ruleResult = results as string;
-        if (ruleResult.includes('No rule violations found.')) {
+        if (this.checkForNoViolation(results)) {
             return [];
         }
         return results as RuleResult[];
+    }
+
+    private checkForNoViolation(results: AnyJson): boolean {
+        const ruleResult = results as string;
+        return ruleResult.includes('No rule violations found.');
     }
 }

--- a/src/test/suite/scanner.test.ts
+++ b/src/test/suite/scanner.test.ts
@@ -13,7 +13,6 @@ import * as File from '../../lib/file';
 import {ScanRunner} from '../../lib/scanner';
 import { Inputs } from '@salesforce/sfdx-scanner/lib/types';
 import { RuleResult } from '../../types';
-import { AnyJson } from "@salesforce/ts-types";
 
 suite('ScanRunner', () => {
     suite('#createPathlessArgArray()', () => {

--- a/src/test/suite/scanner.test.ts
+++ b/src/test/suite/scanner.test.ts
@@ -12,6 +12,8 @@ import {messages} from '../../lib/messages';
 import * as File from '../../lib/file';
 import {ScanRunner} from '../../lib/scanner';
 import { Inputs } from '@salesforce/sfdx-scanner/lib/types';
+import { RuleResult } from '../../types';
+import { AnyJson } from "@salesforce/ts-types";
 
 suite('ScanRunner', () => {
     suite('#createPathlessArgArray()', () => {
@@ -111,6 +113,48 @@ suite('ScanRunner', () => {
                 expect(args['engine']).to.equal('pmd,retire-js', 'Wrong arg');
                 expect(args['format']).to.equal('json', 'Wrong arg');
             });
+        });
+    });
+
+    suite('#processResults()', () => {
+        test('Returns empty results when no violations found', () => {
+            // ===== SETUP =====
+            const spoofedOutput:string = 'some text. No rule violations found.';
+
+            // ===== TEST =====
+            const scanner = new ScanRunner();
+            const processedResults: RuleResult[] = (scanner as any).processResults(spoofedOutput);
+
+            // ===== ASSERTIONS =====
+            expect(processedResults).to.have.lengthOf(0, 'processed Result not empty.');
+        });
+
+        test('Returns RuleResults when violations found', () => {
+            // ===== SETUP =====
+            const spoofedOutput = [{
+                engine: "pmd",
+                fileName: "fakefile1",
+                violations: [{
+                    ruleName: "fakeRule1",
+                    message: "fake message",
+                    severity: 0,
+                    category: "fake category",
+                    line: 1,
+                    column: 5,
+                    endLine: 5,
+                    endColumn: 50
+                }]}];
+
+            // ===== TEST =====
+            const scanner = new ScanRunner();
+            const processedResults: RuleResult[] = (scanner as any).processResults(spoofedOutput);
+
+            // ===== ASSERTIONS =====
+            expect(processedResults).to.have.lengthOf(1, 'processed Result count incorrect.');
+            expect(processedResults[0].engine).to.equal('pmd');
+            expect(processedResults[0].fileName).to.equal('fakefile1');
+            expect(processedResults[0].violations).to.have.lengthOf(1, 'processed violations count incorrect.');
+            expect(processedResults[0].violations[0].ruleName).to.equal('fakeRule1');
         });
     });
 


### PR DESCRIPTION
This was a regression with removing the CLI dependency and "violations is not iterable" error showed in the output panel. This fix takes care of this.