### PR TITLE
NEW (Extension) @W-13991634@ Add class level PMD violations

### DIFF
--- a/code-fixtures/fixer-tests/MyClass2.cls
+++ b/code-fixtures/fixer-tests/MyClass2.cls
@@ -5,11 +5,21 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 public class MyClass2 {
+
     public static boolean someBooleanMethod() {
+        // some comment that includes public class MyClass2 {
+        return false;
+    }
+    /* some other comment in a single line */
+    public static boolean someOtherBooleanMethod() {
+        /*
+        some other comment that includes public class MyClass 2 {
+        */
         return false;
     }
 
-    public static boolean methodWithComment() { // Behold the glory of this comment. Gaze upon it.
+    public static boolean someOtherMethod() {
+        public static String someString = 'this string has class MyClass2 { ';
         return true;
     }
 }

--- a/code-fixtures/fixer-tests/MyClass2.cls
+++ b/code-fixtures/fixer-tests/MyClass2.cls
@@ -19,7 +19,7 @@ public class MyClass2 {
     }
 
     public static boolean someOtherMethod() {
-        public static String someString = 'this string has class MyClass2 { ';
+        public static String someString = 'this string has \' class MyClass2 { ';
         return true;
     }
     

--- a/code-fixtures/fixer-tests/MyClass2.cls
+++ b/code-fixtures/fixer-tests/MyClass2.cls
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+public class MyClass2 {
+    public static boolean someBooleanMethod() {
+        return false;
+    }
+
+    public static boolean methodWithComment() { // Behold the glory of this comment. Gaze upon it.
+        return true;
+    }
+}

--- a/code-fixtures/fixer-tests/MyClass2.cls
+++ b/code-fixtures/fixer-tests/MyClass2.cls
@@ -22,4 +22,8 @@ public class MyClass2 {
         public static String someString = 'this string has class MyClass2 { ';
         return true;
     }
+    
+    private class MyInnerClass {
+        // Some inner class
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,9 +85,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<vscode
 			outputChannel
 		});
 	});
-	const removeDiagnosticsOnSelectedFile = vscode.commands.registerCommand(Constants.COMMAND_REMOVE_DIAGNOSTRICS_ON_SELECTED_FILE, async (selection: vscode.Uri, multiSelect?: vscode.Uri[]) => {
+	const removeDiagnosticsOnSelectedFile = vscode.commands.registerCommand(Constants.COMMAND_REMOVE_DIAGNOSTICS_ON_SELECTED_FILE, async (selection: vscode.Uri, multiSelect?: vscode.Uri[]) => {
 		return _clearDiagnosticsForSelectedFiles(multiSelect && multiSelect.length > 0 ? multiSelect : [selection], {
-			commandName: Constants.COMMAND_REMOVE_DIAGNOSTRICS_ON_SELECTED_FILE,
+			commandName: Constants.COMMAND_REMOVE_DIAGNOSTICS_ON_SELECTED_FILE,
 			diagnosticCollection,
 			outputChannel
 		});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const COMMAND_RUN_ON_ACTIVE_FILE = 'sfca.runOnActiveFile';
 export const COMMAND_RUN_ON_SELECTED = 'sfca.runOnSelected';
 export const COMMAND_RUN_DFA_ON_SELECTED_METHOD = 'sfca.runDfaOnSelectedMethod';
 export const COMMAND_REMOVE_DIAGNOSTICS_ON_ACTIVE_FILE = 'sfca.removeDiagnosticsOnActiveFile';
-export const COMMAND_REMOVE_DIAGNOSTRICS_ON_SELECTED_FILE = 'sfca.removeDiagnosticsOnSelectedFile';
+export const COMMAND_REMOVE_DIAGNOSTICS_ON_SELECTED_FILE = 'sfca.removeDiagnosticsOnSelectedFile';
 export const COMMAND_REMOVE_SINGLE_DIAGNOSTIC = 'sfca.removeSingleDiagnostic'
 
 

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -136,7 +136,7 @@ export class _PmdFixGenerator extends FixGenerator {
         return action;
     }
 
-    private generateClassLevelSuppression(): vscode.CodeAction {
+    public generateClassLevelSuppression(): vscode.CodeAction {
         // Find the end-of-line position of the class declaration where the diagnostic is found.
         const classStartPosition = this.findClassStartPosition(this.diagnostic, this.document);
         // const classEndOfLinePosition = 0;
@@ -153,7 +153,7 @@ export class _PmdFixGenerator extends FixGenerator {
         }
     
         // Extract text from the start to end of the class declaration to search for existing suppressions
-        const classText = this.findLineBeforeClassStartDeclaration(classStartPosition);
+        const classText = this.findLineBeforeClassStartDeclaration(classStartPosition, this.document);
         const suppressionRegex = /@SuppressWarnings\s*\(\s*'([^']*)'\s*\)/;
         const suppressionMatch = classText.match(suppressionRegex);
     
@@ -177,8 +177,8 @@ export class _PmdFixGenerator extends FixGenerator {
     
         action.diagnostics = [this.diagnostic];
         action.command = {
-            command: Constants.COMMAND_RUN_ON_SELECTED,
-            title: 'Re-run diagnostic for this file',
+            command: Constants.COMMAND_REMOVE_DIAGNOSTICS_ON_SELECTED_FILE,
+            title: 'Remove diagnostics for this file',
             arguments: [this.document.uri]
         };
 
@@ -190,7 +190,7 @@ export class _PmdFixGenerator extends FixGenerator {
      * Assumes that the class declaration starts with the keyword "class".
      * @returns The position at the start of the class.
      */
-    private findClassStartPosition(diagnostic: vscode.Diagnostic, document: vscode.TextDocument): vscode.Position {
+    public findClassStartPosition(diagnostic: vscode.Diagnostic, document: vscode.TextDocument): vscode.Position {
         const text = document.getText();
         const diagnosticLine = diagnostic.range.start.line;
     
@@ -221,11 +221,11 @@ export class _PmdFixGenerator extends FixGenerator {
      * Assumes that the class declaration starts with the keyword "class".
      * @returns The text of the line that is one line above the class declaration.
      */
-    private findLineBeforeClassStartDeclaration(classStartPosition: vscode.Position): string {
+    public findLineBeforeClassStartDeclaration(classStartPosition: vscode.Position, document: vscode.TextDocument): string {
         // Ensure that there is a line before the class declaration
         if (classStartPosition.line > 0) {
             const lineBeforeClassPosition = classStartPosition.line - 1;
-            const lineBeforeClass = this.document.lineAt(lineBeforeClassPosition);
+            const lineBeforeClass = document.lineAt(lineBeforeClassPosition);
             return lineBeforeClass.text;
         }
 

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -32,7 +32,8 @@ export const messages = {
         existingDfaRunText: "A Salesforce Graph Engine analysis is already running. Cancel it by clicking in the Status Bar.",
     },
     fixer: {
-        supressOnLine: "Suppress violations on this line."
+        supressOnLine: "Suppress violations on this line.",
+        supressOnClass: "***Suppress violations on this class.***"
     },
     diagnostics: {
         messageGenerator: (severity: number, message: string) => `Sev${severity}: ${message}`,

--- a/src/test/suite/fixer.test.ts
+++ b/src/test/suite/fixer.test.ts
@@ -133,7 +133,7 @@ suite('fixer.ts', () => {
                 });
 
                 suite('Class-level suppression', () => {
-                    test('Find class start position above the diagnostic line', async () => {
+                    test('Should find class start position above the diagnostic line', async () => {
                         const fileUri = vscode.Uri.file(path.join(codeFixturesPath, 'MyClass1.cls'));
 
                         let doc: vscode.TextDocument;
@@ -157,6 +157,82 @@ suite('fixer.ts', () => {
                         expect(position.line).to.equal(6);
                         expect(position.character).to.equal(0);
                     });
+
+                    test('Should ignore class defined in single line comment', async () => {
+                        const fileUri = vscode.Uri.file(path.join(codeFixturesPath, 'MyClass2.cls'));
+
+                        let doc: vscode.TextDocument;
+                        doc = await vscode.workspace.openTextDocument(fileUri);
+                        const diag = new vscode.Diagnostic(
+                            new vscode.Range(
+                                new vscode.Position(10, 0),
+                                new vscode.Position(10, 1)
+                            ),
+                            'This message is unimportant',
+                            vscode.DiagnosticSeverity.Warning
+                        );
+
+                        // Instantiate our fixer
+                        const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
+
+                        // Call findClassStartPosition method
+                        const position = fixGenerator.findClassStartPosition(diag, doc);
+
+                        // Verify the position is correct
+                        expect(position.line).to.equal(6);
+                        expect(position.character).to.equal(0);
+                    });
+
+                    test('Should ignore class defined in a block comment comment', async () => {
+                        const fileUri = vscode.Uri.file(path.join(codeFixturesPath, 'MyClass2.cls'));
+
+                        let doc: vscode.TextDocument;
+                        doc = await vscode.workspace.openTextDocument(fileUri);
+                        const diag = new vscode.Diagnostic(
+                            new vscode.Range(
+                                new vscode.Position(17, 0),
+                                new vscode.Position(17, 1)
+                            ),
+                            'This message is unimportant',
+                            vscode.DiagnosticSeverity.Warning
+                        );
+
+                        // Instantiate our fixer
+                        const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
+
+                        // Call findClassStartPosition method
+                        const position = fixGenerator.findClassStartPosition(diag, doc);
+
+                        // Verify the position is correct
+                        expect(position.line).to.equal(6);
+                        expect(position.character).to.equal(0);
+                    });
+
+                    test('Should ignore class defined as a string', async () => {
+                        const fileUri = vscode.Uri.file(path.join(codeFixturesPath, 'MyClass2.cls'));
+
+                        let doc: vscode.TextDocument;
+                        doc = await vscode.workspace.openTextDocument(fileUri);
+                        const diag = new vscode.Diagnostic(
+                            new vscode.Range(
+                                new vscode.Position(23, 0),
+                                new vscode.Position(23, 1)
+                            ),
+                            'This message is unimportant',
+                            vscode.DiagnosticSeverity.Warning
+                        );
+
+                        // Instantiate our fixer
+                        const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
+
+                        // Call findClassStartPosition method
+                        const position = fixGenerator.findClassStartPosition(diag, doc);
+
+                        // Verify the position is correct
+                        expect(position.line).to.equal(6);
+                        expect(position.character).to.equal(0);
+                    });
+
                 });
             });
         });

--- a/src/test/suite/fixer.test.ts
+++ b/src/test/suite/fixer.test.ts
@@ -124,8 +124,8 @@ suite('fixer.ts', () => {
                         // Attempt to generate fixes for the file.
                         const fixes: vscode.CodeAction[] = fixGenerator.generateFixes(existingFixes);
 
-                        // We expect to get no fix, since there is already a fix
-                        expect(fixes).to.have.lengthOf(0, 'Wrong action count');
+                        // We expect to get one fix (class level suppression), no new line level suppression added since there is already a fix
+                        expect(fixes).to.have.lengthOf(1, 'Wrong action count');
                     });
 
                     /*


### PR DESCRIPTION
This PR does the following:
1. Injects PMD's class-level suppression syntax to silence a single rule for that class (i.e., `@SuppressWarnings` syntax).
2. Identifies the specific rule to be suppressed and adds the appropriate syntax (Example: `@SuppressWarnings('PMD.ApexDoc')`).
3. If a class-level suppression tag already exists, it changes the SuppressWarnings accordingly (Example: `@SuppressWarnings('PMD.ApexDoc', 'PMD.UnusedMethod')`), instead of adding a new tag.
4. Adds the tag for Apex and Java appropriately (double-quotes for Java).
5. Identifies the correct position to add this tag by regex parsing the file for 'class', but at the same type ignoring 'class' defined as a comment or as part of a string. 