### PR TITLE
NEW (Extension) @W-13992309@ Remove duplicate suppress violations prompts on the same line

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,7 +15,7 @@ export const COMMAND_RUN_ON_SELECTED = 'sfca.runOnSelected';
 export const COMMAND_RUN_DFA_ON_SELECTED_METHOD = 'sfca.runDfaOnSelectedMethod';
 export const COMMAND_REMOVE_DIAGNOSTICS_ON_ACTIVE_FILE = 'sfca.removeDiagnosticsOnActiveFile';
 export const COMMAND_REMOVE_DIAGNOSTRICS_ON_SELECTED_FILE = 'sfca.removeDiagnosticsOnSelectedFile';
-export const COMMAND_REMOVE_SINGLE_DIAGNOSTIC = 'sfca.removeSingleDiagnostic'
+export const COMMAND_DIAGNOSTICS_IN_RANGE = 'sfca.removeDiagnosticsInRange'
 
 
 // telemetry event keys

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -99,6 +99,8 @@ export class _PmdFixGenerator extends FixGenerator {
     public generateFixes(processedLines: Set<number>): vscode.CodeAction[] {
         const fixes: vscode.CodeAction[] = [];
         if (this.documentSupportsLineLevelSuppression()) {
+            // We only check for the start line and not the entire range because irrespective of the range of a specific violation,
+            // we add the NOPMD tag only on the first line of the violation.
             const lineNumber = this.diagnostic.range.start.line;
             if (!processedLines.has(lineNumber)) {
                 fixes.push(this.generateLineLevelSuppression());

--- a/src/lib/fixer.ts
+++ b/src/lib/fixer.ts
@@ -20,12 +20,13 @@ export class Fixer implements vscode.CodeActionProvider {
      * @returns All actions corresponding to diagnostics in the specified range of the target document.
      */
     public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): vscode.CodeAction[] {
+        const processedLines = new Set<number>(); 
         // Iterate over all diagnostics.
         return context.diagnostics
             // Throw out diagnostics that aren't ours, or are for the wrong line.
             .filter(diagnostic => messages.diagnostics.source && messages.diagnostics.source.isSource(diagnostic.source) && diagnostic.range.isEqual(range))
             // Get and use the appropriate fix generator.
-            .map(diagnostic => this.getFixGenerator(document, diagnostic).generateFixes())
+            .map(diagnostic => this.getFixGenerator(document, diagnostic).generateFixes(processedLines))
             // Combine all the fixes into one array.
             .reduce((acc, next) => [...acc, ...next], []);
     }
@@ -72,7 +73,7 @@ abstract class FixGenerator {
      * Abstract template method for generating fixes.
      * @abstract
      */
-    public abstract generateFixes(): vscode.CodeAction[];
+    public abstract generateFixes(processedLines: Set<number>): vscode.CodeAction[];
 }
 
 /**
@@ -80,7 +81,8 @@ abstract class FixGenerator {
  * @private Must be exported for testing purposes, but shouldn't be used publicly, hence the leading underscore.
  */
 export class _NoOpFixGenerator extends FixGenerator {
-    public generateFixes(): vscode.CodeAction[] {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public generateFixes(processedLines: Set<number>): vscode.CodeAction[] {
         return [];
     }
 }
@@ -94,10 +96,14 @@ export class _PmdFixGenerator extends FixGenerator {
      * Generate an array of fixes, if possible.
      * @returns
      */
-    public generateFixes(): vscode.CodeAction[] {
+    public generateFixes(processedLines: Set<number>): vscode.CodeAction[] {
         const fixes: vscode.CodeAction[] = [];
         if (this.documentSupportsLineLevelSuppression()) {
-            fixes.push(this.generateLineLevelSuppression());
+            const lineNumber = this.diagnostic.range.start.line;
+            if (!processedLines.has(lineNumber)) {
+                fixes.push(this.generateLineLevelSuppression());
+                processedLines.add(lineNumber);
+            }
         }
         return fixes;
     }
@@ -127,9 +133,9 @@ export class _PmdFixGenerator extends FixGenerator {
         action.edit.insert(this.document.uri, endOfLine, " // NOPMD");
         action.diagnostics = [this.diagnostic];
         action.command = {
-            command: Constants.COMMAND_REMOVE_SINGLE_DIAGNOSTIC,
+            command: Constants.COMMAND_DIAGNOSTICS_IN_RANGE,
             title: 'Clear Single Diagnostic',
-            arguments: [this.document.uri, this.diagnostic]
+            arguments: [this.document.uri, this.diagnostic.range]
         };
         return action;
     }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ import {expect} from 'chai';
 import path = require('path');
 import {SfCli} from '../../lib/sf-cli';
 import Sinon = require('sinon');
-import { _runAndDisplayPathless, _runAndDisplayDfa, _clearDiagnostics, _shouldProceedWithDfaRun, _stopExistingDfaRun, _isValidFileForAnalysis, verifyPluginInstallation, _clearDiagnosticsForSelectedFiles, _removeSingleDiagnostic, RunInfo } from '../../extension';
+import { _runAndDisplayPathless, _runAndDisplayDfa, _clearDiagnostics, _shouldProceedWithDfaRun, _stopExistingDfaRun, _isValidFileForAnalysis, verifyPluginInstallation, _clearDiagnosticsForSelectedFiles, _removeDiagnosticsInRange, RunInfo } from '../../extension';
 import {messages} from '../../lib/messages';
 import {TelemetryService} from '../../lib/core-extension-service';
 import * as Constants from '../../lib/constants';
@@ -559,7 +559,7 @@ suite('Extension Test Suite', () => {
 			expect(diagnosticCollection.get(uri)).to.have.lengthOf(2, 'Expected two diagnostics to be present before removal');
 	
 			// ===== TEST =====
-			_removeSingleDiagnostic(uri, diagnosticToRemove, diagnosticCollection);
+			_removeDiagnosticsInRange(uri, diagnosticToRemove.range, diagnosticCollection);
 	
 			// ===== ASSERTIONS =====
 			const remainingDiagnostics = diagnosticCollection.get(uri);
@@ -575,7 +575,7 @@ suite('Extension Test Suite', () => {
 			expect(diagnosticCollection.get(uri)).to.be.empty;
 	
 			// ===== TEST =====
-			_removeSingleDiagnostic(uri, diagnosticToRemove, diagnosticCollection);
+			_removeDiagnosticsInRange(uri, diagnosticToRemove.range, diagnosticCollection);
 	
 			// ===== ASSERTIONS =====
 			const remainingDiagnostics = diagnosticCollection.get(uri);
@@ -594,7 +594,7 @@ suite('Extension Test Suite', () => {
 			expect(diagnosticCollection.get(uri)).to.have.lengthOf(1, 'Expected one diagnostic to be present before attempting removal');
 	
 			// ===== TEST =====
-			_removeSingleDiagnostic(uri, diagnosticToRemove, diagnosticCollection);
+			_removeDiagnosticsInRange(uri, diagnosticToRemove.range, diagnosticCollection);
 	
 			// ===== ASSERTIONS =====
 			const remainingDiagnostics = diagnosticCollection.get(uri);

--- a/src/test/suite/fixer.test.ts
+++ b/src/test/suite/fixer.test.ts
@@ -107,11 +107,11 @@ suite('fixer.ts', () => {
 
                     test('Does not add suppression if suppression for that same line already exists', async () => {
                         existingFixes.add(7);
-                        // Create our fake diagnostic, positioned at the line with no comment at the end.
+                        // Create our fake diagnostic whose start position is the same as the existing fix already added
                         const diag = new vscode.Diagnostic(
                             new vscode.Range(
-                                new vscode.Position(7, 4),
-                                new vscode.Position(7, 10)
+                                new vscode.Position(7, 0),
+                                new vscode.Position(8, 0)
                             ),
                             'This message is unimportant',
                             vscode.DiagnosticSeverity.Warning

--- a/src/test/suite/fixer.test.ts
+++ b/src/test/suite/fixer.test.ts
@@ -20,13 +20,14 @@ suite('fixer.ts', () => {
 	});
 
     suite('_NoOpFixGenerator', () => {
+        const existingFixes = new Set<number>(); 
         suite('#generateFixes()', () => {
             test('Returns empty array', () => {
                 // Doesn't matter what we feed to the no-op constructor.
                 const fixGenerator = new _NoOpFixGenerator(null, null);
 
                 // Attempt to generate fixes.
-                const fixes: vscode.CodeAction[] = fixGenerator.generateFixes();
+                const fixes: vscode.CodeAction[] = fixGenerator.generateFixes(existingFixes);
 
                 // Verify array is empty.
                 expect(fixes).to.have.lengthOf(0, 'Should be no fixes');
@@ -59,7 +60,7 @@ suite('fixer.ts', () => {
                     const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
 
                     // Attempt to generate fixes for the file.
-                    const fixes: vscode.CodeAction[] = fixGenerator.generateFixes();
+                    const fixes: vscode.CodeAction[] = fixGenerator.generateFixes(null);
 
                     // We should get none.
                     expect(fixes).to.have.lengthOf(0, 'No fixes should be offered');
@@ -79,6 +80,7 @@ suite('fixer.ts', () => {
                 });
 
                 suite('Line-level suppression', () => {
+                    const existingFixes = new Set<number>(); 
                     test('Appends suppression to end of commentless line', async () => {
                         // Create our fake diagnostic, positioned at the line with no comment at the end.
                         const diag = new vscode.Diagnostic(
@@ -94,13 +96,35 @@ suite('fixer.ts', () => {
                         const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
 
                         // Attempt to generate fixes for the file.
-                        const fixes: vscode.CodeAction[] = fixGenerator.generateFixes();
+                        const fixes: vscode.CodeAction[] = fixGenerator.generateFixes(existingFixes);
 
                         // We expect to get one fix, to inject the suppression at the end of the line.
                         expect(fixes).to.have.lengthOf(1, 'Wrong action count');
                         const fix = fixes[0].edit.get(fileUri)[0];
                         expect(fix.newText).to.equal(' // NOPMD', 'Wrong suppression added');
                         expect(fix.range.start.isEqual(new vscode.Position(7, Number.MAX_SAFE_INTEGER))).to.equal(true, 'Should be at the end of the violation line');
+                    });
+
+                    test('Does not add suppression if suppression for that same line already exists', async () => {
+                        existingFixes.add(7);
+                        // Create our fake diagnostic, positioned at the line with no comment at the end.
+                        const diag = new vscode.Diagnostic(
+                            new vscode.Range(
+                                new vscode.Position(7, 4),
+                                new vscode.Position(7, 10)
+                            ),
+                            'This message is unimportant',
+                            vscode.DiagnosticSeverity.Warning
+                        );
+
+                        // Instantiate our fixer.
+                        const fixGenerator: _PmdFixGenerator = new _PmdFixGenerator(doc, diag);
+
+                        // Attempt to generate fixes for the file.
+                        const fixes: vscode.CodeAction[] = fixGenerator.generateFixes(existingFixes);
+
+                        // We expect to get no fix, since there is already a fix
+                        expect(fixes).to.have.lengthOf(0, 'Wrong action count');
                     });
 
                     /*


### PR DESCRIPTION
This PR does the following:
1. Shows only one "suppress warning" per line on the editor and in the "Problems" tab per line even if there are multiple violations were found on a line. Previously, multiple "suppress warning"s would show up and they all would add the same "// NOPMD" tag.
2. Additionally, this PR also clears all the diagnostics on the line automatically. We do this by changing the removeSingleDiagnostics command to a more generic removeDiagnosticsInRange that clears all diagnostics in a given range.