### PR TITLE
NEW (Extension) @W-16002080@ Add eslint support and additional parameters for the scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,10 +132,10 @@
                     "default": false,
                     "description": "Scan files on open automatically."
                 },
-                "codeAnalyzer.eslint.engine": {
+                "codeAnalyzer.scanner.engines": {
                     "type": "string",
-                    "default": "eslint-lwc",
-                    "description": "***Specifies one or more variants of eslint engines to run. Submit multiple values as a comma-separated list. Possible values are eslint, eslint-lwc and eslint-typescript***"
+                    "default": "pmd,retire-js,eslint-lwc",
+                    "description": "***Specifies the engines to run. Submit multiple values as a comma-separated list. Possible values are pmd, retire-js, eslint, eslint-lwc and eslint-typescript***"
                 },
                 "codeAnalyzer.normalizeSeverity.enabled": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -103,11 +103,6 @@
                     "default": "",
                     "description": "Replace Code Analyzer's default PMD config file, choose a custom file."
                 },
-                "codeAnalyzer.pMD.disable": {
-                    "type": "boolean",
-                    "default": "false",
-                    "description": "***Exclude PMD engine while scanning.***"
-                },
                 "codeAnalyzer.graphEngine.disableWarningViolations": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
                     "default": "",
                     "description": "Replace Code Analyzer's default PMD config file, choose a custom file."
                 },
+                "codeAnalyzer.pMD.disable": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "***Exclude PMD engine while scanning.***"
+                },
                 "codeAnalyzer.graphEngine.disableWarningViolations": {
                     "type": "boolean",
                     "default": false,
@@ -131,6 +136,20 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Scan files on open automatically."
+                },
+                "codeAnalyzer.eslint.engine": {
+                    "type": "string",
+                    "default": "eslint-lwc",
+                    "description": "***Specifies one or more variants of eslint engines to run. Submit multiple values as a comma-separated list. Possible values are eslint, eslint-lwc and eslint-typescript***"
+                },
+                "codeAnalyzer.normalizeSeverity.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "***Enable this flag to output normalized severity and engine-specific severity across all engines.***"
+                },
+                "codeAnalyzer.rules.category": {
+                    "type": "string",
+                    "description": "***One or more categories of rules to run. Specify multiple values as a comma-separated list.***"
                 }
             }
         },

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -101,10 +101,18 @@ export class ScanRunner {
      * @param targets The files to be scanned.
      */
     private async createPathlessArgArray(targets: string[]): Promise<string[]> {
+        const eslintEngine = SettingsManager.getEslintEngine();
+
+        const engines = ['retire-js', 'pmd'];
+
+        if (eslintEngine) {
+            engines.push(eslintEngine);
+        }
+    
         const args: string[] = [
             'scanner', 'run',
             '--target', `${targets.join(',')}`,
-            '--engine', 'pmd,retire-js',
+            '--engine', engines.join(','),
             '--json'
         ];
         const customPmdConfig: string = SettingsManager.getPmdCustomConfigFile();
@@ -114,6 +122,15 @@ export class ScanRunner {
                 throw new Error(messages.error.pmdConfigNotFoundGenerator(customPmdConfig));
             }
             args.push('--pmdconfig', customPmdConfig);
+        }
+
+        const rulesCategory = SettingsManager.getRulesCategory();
+        if (rulesCategory) {
+            args.push('--category', rulesCategory);
+        }
+
+        if (SettingsManager.getNormalizeSeverityEnabled()) {
+            args.push('--normalize-severity')
         }
         return args;
     }

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -101,18 +101,16 @@ export class ScanRunner {
      * @param targets The files to be scanned.
      */
     private async createPathlessArgArray(targets: string[]): Promise<string[]> {
-        const eslintEngine = SettingsManager.getEslintEngine();
-
-        const engines = ['retire-js', 'pmd'];
-
-        if (eslintEngine) {
-            engines.push(eslintEngine);
-        }
+        const engines = SettingsManager.getEnginesToRun();
     
+        if (!engines || engines.length === 0) {
+            throw new Error('***Engines cannot be empty. Please set one or more engines in the VS Code Settings***');
+        }
+
         const args: string[] = [
             'scanner', 'run',
             '--target', `${targets.join(',')}`,
-            '--engine', engines.join(','),
+            '--engine', engines,
             '--json'
         ];
         const customPmdConfig: string = SettingsManager.getPmdCustomConfigFile();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -38,8 +38,8 @@ export class SettingsManager {
         return vscode.workspace.getConfiguration('codeAnalyzer.analyzeOnOpen').get('enabled');
     }
 
-    public static getEslintEngine(): string {
-        return vscode.workspace.getConfiguration('codeAnalyzer.eslint').get('engine');
+    public static getEnginesToRun(): string {
+        return vscode.workspace.getConfiguration('codeAnalyzer.scanner').get('engines');
     }
 
     public static getNormalizeSeverityEnabled(): boolean {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -14,6 +14,10 @@ export class SettingsManager {
         return vscode.workspace.getConfiguration('codeAnalyzer.pMD').get('customConfigFile');
     }
 
+    public static getPmdDisabled(): boolean {
+        return vscode.workspace.getConfiguration('codeAnalyzer.pMD').get('disable');
+    }
+
     public static getGraphEngineDisableWarningViolations(): boolean {
         return vscode.workspace.getConfiguration('codeAnalyzer.graphEngine').get('disableWarningViolations');
     }
@@ -36,5 +40,17 @@ export class SettingsManager {
 
     public static getAnalyzeOnOpen(): boolean {
         return vscode.workspace.getConfiguration('codeAnalyzer.analyzeOnOpen').get('enabled');
+    }
+
+    public static getEslintEngine(): string {
+        return vscode.workspace.getConfiguration('codeAnalyzer.eslint').get('engine');
+    }
+
+    public static getNormalizeSeverityEnabled(): boolean {
+        return vscode.workspace.getConfiguration('codeAnalyzer.normalizeSeverity').get('enabled');
+    }
+
+    public static getRulesCategory(): string {
+        return vscode.workspace.getConfiguration('codeAnalyzer.rules').get('category');
     }
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -14,10 +14,6 @@ export class SettingsManager {
         return vscode.workspace.getConfiguration('codeAnalyzer.pMD').get('customConfigFile');
     }
 
-    public static getPmdDisabled(): boolean {
-        return vscode.workspace.getConfiguration('codeAnalyzer.pMD').get('disable');
-    }
-
     public static getGraphEngineDisableWarningViolations(): boolean {
         return vscode.workspace.getConfiguration('codeAnalyzer.graphEngine').get('disableWarningViolations');
     }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -40,6 +40,9 @@ suite('Extension Test Suite', () => {
 			for (const [uri, diagnostics] of diagnosticsArrays) {
 				expect(diagnostics, `${uri.toString()} should start without diagnostics`).to.be.empty;
 			}
+			// Set custom settings
+			const configuration = vscode.workspace.getConfiguration();
+			configuration.update('codeAnalyzer.scanner.engines', 'pmd,retire-js,eslint-lwc', vscode.ConfigurationTarget.Global);
 		});
 
 		teardown(async () => {

--- a/src/test/suite/scanner.test.ts
+++ b/src/test/suite/scanner.test.ts
@@ -36,8 +36,19 @@ suite('ScanRunner', () => {
             return (scanner as any).createPathlessArgArray(targets);
         }
 
-        suite('Simple cases', () => {
+        suite('Non Custom PMD Config, with various parameter options', () => {
+            teardown(() => {
+                // Revert any stubbing we did with Sinon.
+                Sinon.restore();
+            });
+
             test('Creates array-ified sfdx-scanner command', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                Sinon.stub(SettingsManager, 'getEslintEngine').returns("");
+                Sinon.stub(SettingsManager, 'getRulesCategory').returns("");
+                Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(false);
+                
                 // ===== TEST =====
                 // Call the test method helper.
                 const args: string[] = await invokeTestedMethod();
@@ -50,8 +61,65 @@ suite('ScanRunner', () => {
                 expect(args[2]).to.equal('--target', 'Wrong arg');
                 expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
                 expect(args[4]).to.equal('--engine', 'Wrong arg');
-                expect(args[5]).to.equal('pmd,retire-js', 'Wrong arg');
+                expect(args[5]).to.equal('retire-js,pmd', 'Wrong arg');
                 expect(args[6]).to.equal('--json', 'Wrong arg');
+            });
+
+            test('Includes eslintEngine in the --engine parameter if provided', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                const eslintEngine = 'eslint';
+                Sinon.stub(SettingsManager, 'getEslintEngine').returns(eslintEngine);
+                Sinon.stub(SettingsManager, 'getRulesCategory').returns("");
+                Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(false);
+    
+                // ===== TEST =====
+                // Call the test method helper.
+                const args: string[] = await invokeTestedMethod();
+    
+                // ===== ASSERTIONS =====
+                // Verify that the right arguments were created.
+                expect(args).to.have.lengthOf(7, 'Wrong number of args');
+                expect(args[0]).to.equal('scanner', 'Wrong arg');
+                expect(args[1]).to.equal('run', 'Wrong arg');
+                expect(args[2]).to.equal('--target', 'Wrong arg');
+                expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
+                expect(args[4]).to.equal('--engine', 'Wrong arg');
+                expect(args[5]).to.equal('retire-js,pmd,eslint', 'Wrong arg');
+                expect(args[6]).to.equal('--json', 'Wrong arg');
+            });
+
+            test('Includes rulesCategory in the --category parameter if provided', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                const ruleCategory = 'security';
+                Sinon.stub(SettingsManager, 'getRulesCategory').returns(ruleCategory);
+                Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(false);
+    
+                // ===== TEST =====
+                // Call the test method helper.
+                const args: string[] = await invokeTestedMethod();
+    
+                // ===== ASSERTIONS =====
+                // Verify that the right arguments were created.
+                // expect(args).to.have.lengthOf(9, 'Wrong number of args');
+                expect(args[7]).to.equal('--category', 'Wrong arg');
+                expect(args[8]).to.equal(ruleCategory, 'Wrong arg');
+            });
+
+            test('Includes --normalize-severity parameter if flag enabled', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(true);
+    
+                // ===== TEST =====
+                // Call the test method helper.
+                const args: string[] = await invokeTestedMethod();
+    
+                // ===== ASSERTIONS =====
+                // Verify that the right arguments were created.
+                // expect(args).to.have.lengthOf(9, 'Wrong number of args');
+                expect(args[7]).to.equal('--normalize-severity', 'Wrong arg');
             });
         });
 
@@ -68,6 +136,7 @@ suite('ScanRunner', () => {
                 const dummyConfigPath: string = '/Users/me/someconfig.xml';
                 Sinon.stub(SettingsManager, 'getPmdCustomConfigFile').returns(dummyConfigPath);
                 Sinon.stub(File, 'exists').resolves(true);
+                Sinon.stub(SettingsManager, 'getEslintEngine').returns('');
 
                 // ===== TEST =====
                 // Call the test method helper.
@@ -81,7 +150,7 @@ suite('ScanRunner', () => {
                 expect(args[2]).to.equal('--target', 'Wrong arg');
                 expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
                 expect(args[4]).to.equal('--engine', 'Wrong arg');
-                expect(args[5]).to.equal('pmd,retire-js', 'Wrong arg');
+                expect(args[5]).to.equal('retire-js,pmd', 'Wrong arg');
                 expect(args[6]).to.equal('--json', 'Wrong arg');
                 expect(args[7]).to.equal('--pmdconfig', 'Wrong arg');
                 expect(args[8]).to.equal(dummyConfigPath, 'Wrong arg');
@@ -114,6 +183,7 @@ suite('ScanRunner', () => {
                 // ===== SETUP =====
                 // Stub out the appropriate SettingsManager method to return an empty string.
                 Sinon.stub(SettingsManager, 'getPmdCustomConfigFile').returns("");
+                Sinon.stub(SettingsManager, 'getEslintEngine').returns('');
 
                 // ===== TEST =====
                 // Call the test method helper.
@@ -127,7 +197,7 @@ suite('ScanRunner', () => {
                 expect(args[2]).to.equal('--target', 'Wrong arg');
                 expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
                 expect(args[4]).to.equal('--engine', 'Wrong arg');
-                expect(args[5]).to.equal('pmd,retire-js', 'Wrong arg');
+                expect(args[5]).to.equal('retire-js,pmd', 'Wrong arg');
                 expect(args[6]).to.equal('--json', 'Wrong arg');
             });
         });

--- a/src/test/suite/scanner.test.ts
+++ b/src/test/suite/scanner.test.ts
@@ -45,7 +45,7 @@ suite('ScanRunner', () => {
             test('Creates array-ified sfdx-scanner command', async () => {
                 // ===== SETUP =====
                 // Stub out the appropriate SettingsManager methods.
-                Sinon.stub(SettingsManager, 'getEslintEngine').returns("");
+                Sinon.stub(SettingsManager, 'getEnginesToRun').returns("retire-js,pmd");
                 Sinon.stub(SettingsManager, 'getRulesCategory').returns("");
                 Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(false);
                 
@@ -62,30 +62,6 @@ suite('ScanRunner', () => {
                 expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
                 expect(args[4]).to.equal('--engine', 'Wrong arg');
                 expect(args[5]).to.equal('retire-js,pmd', 'Wrong arg');
-                expect(args[6]).to.equal('--json', 'Wrong arg');
-            });
-
-            test('Includes eslintEngine in the --engine parameter if provided', async () => {
-                // ===== SETUP =====
-                // Stub out the appropriate SettingsManager methods.
-                const eslintEngine = 'eslint';
-                Sinon.stub(SettingsManager, 'getEslintEngine').returns(eslintEngine);
-                Sinon.stub(SettingsManager, 'getRulesCategory').returns("");
-                Sinon.stub(SettingsManager, 'getNormalizeSeverityEnabled').returns(false);
-    
-                // ===== TEST =====
-                // Call the test method helper.
-                const args: string[] = await invokeTestedMethod();
-    
-                // ===== ASSERTIONS =====
-                // Verify that the right arguments were created.
-                expect(args).to.have.lengthOf(7, 'Wrong number of args');
-                expect(args[0]).to.equal('scanner', 'Wrong arg');
-                expect(args[1]).to.equal('run', 'Wrong arg');
-                expect(args[2]).to.equal('--target', 'Wrong arg');
-                expect(args[3]).to.equal(targets.join(','), 'Wrong arg');
-                expect(args[4]).to.equal('--engine', 'Wrong arg');
-                expect(args[5]).to.equal('retire-js,pmd,eslint', 'Wrong arg');
                 expect(args[6]).to.equal('--json', 'Wrong arg');
             });
 
@@ -118,8 +94,43 @@ suite('ScanRunner', () => {
     
                 // ===== ASSERTIONS =====
                 // Verify that the right arguments were created.
-                // expect(args).to.have.lengthOf(9, 'Wrong number of args');
                 expect(args[7]).to.equal('--normalize-severity', 'Wrong arg');
+            });
+
+            test('Error thrown when codeAnalyzer.scanner.engines is empty', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                Sinon.stub(SettingsManager, 'getEnginesToRun').returns('');
+    
+                // ===== TEST =====
+                let err:Error = null;
+                try {
+                    await invokeTestedMethod();
+                } catch (e) {
+                    err = e;
+                }
+    
+                // ===== ASSERTIONS =====
+                expect(err).to.exist;
+                expect(err.message).to.equal('***Engines cannot be empty. Please set one or more engines in the VS Code Settings***');
+            });
+
+            test('Error thrown when codeAnalyzer.scanner.engines is undefined', async () => {
+                // ===== SETUP =====
+                // Stub out the appropriate SettingsManager methods.
+                Sinon.stub(SettingsManager, 'getEnginesToRun').returns(undefined);
+    
+                // ===== TEST =====
+                let err:Error = null;
+                try {
+                    await invokeTestedMethod();
+                } catch (e) {
+                    err = e;
+                }
+    
+                // ===== ASSERTIONS =====
+                expect(err).to.exist;
+                expect(err.message).to.equal('***Engines cannot be empty. Please set one or more engines in the VS Code Settings***');
             });
         });
 
@@ -136,7 +147,7 @@ suite('ScanRunner', () => {
                 const dummyConfigPath: string = '/Users/me/someconfig.xml';
                 Sinon.stub(SettingsManager, 'getPmdCustomConfigFile').returns(dummyConfigPath);
                 Sinon.stub(File, 'exists').resolves(true);
-                Sinon.stub(SettingsManager, 'getEslintEngine').returns('');
+                Sinon.stub(SettingsManager, 'getEnginesToRun').returns('retire-js,pmd');
 
                 // ===== TEST =====
                 // Call the test method helper.
@@ -183,7 +194,7 @@ suite('ScanRunner', () => {
                 // ===== SETUP =====
                 // Stub out the appropriate SettingsManager method to return an empty string.
                 Sinon.stub(SettingsManager, 'getPmdCustomConfigFile').returns("");
-                Sinon.stub(SettingsManager, 'getEslintEngine').returns('');
+                Sinon.stub(SettingsManager, 'getEnginesToRun').returns('retire-js,pmd');
 
                 // ===== TEST =====
                 // Call the test method helper.


### PR DESCRIPTION
This PR does the following:

- Adding eslint support to the VS Code Extension. We do this by adding eslint-lwc as the default engine that would be executed. Users can change this to eslint or eslint-typescript in the settings.
- The list of engines to run is completely configurable and hence pmd can be removed if needed.
- Exposes a “normalize severity” flag as a setting and when that is turned on, we normalize the severity similar to CLI. This flag is turned off by default.
- Exposes a “category” flag as a setting that is empty by default and can be overridden to a value by the users. When set, only those category rules are scanned.
