### PR TITLE
NEW (Extension) @W-16442046@ do not throw error when source is undefined

### DIFF
--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -39,7 +39,13 @@ export const messages = {
         messageGenerator: (severity: number, message: string) => `Sev${severity}: ${message}`,
         source: {
             generator: (engine: string) => `${engine} via Code Analyzer`,
-            isSource: (source: string) => source.endsWith(' via Code Analyzer'),
+            isSource: (source: string) => {
+                if (!source) {
+                    return false;
+                }
+                
+                return source.endsWith(' via Code Analyzer');
+            },
             extractEngine: (source: string) => source.split(' ')[0]
         }
     },


### PR DESCRIPTION
Kept seeing an error in VSCode randomly associated with CA extension.  Figured I'd take a quick peek to see if I could figure out why. 

Root cause here: https://github.com/forcedotcom/sfdx-code-analyzer-vscode/blob/4ed5252d599d00ba8b7ddb103f9ede07550f794a/src/lib/fixer.ts#L27

I can't really explain why TS isn't complaining about the string | undefined mismatch with the isSource method, but this should prevent the error. 

I didn't see any tests covering this area, but lemme know if I missed it. 