### PR TITLE
NEW (CodeAnalyzerV5) @W-17681987@ Reorganized settings to eventually support Code Analyzer v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,33 +115,9 @@
                 "title": "SFDX: Scan Current File for Performance Issues with ApexGuru"
             }
         ],
-        "configuration": {
-            "title": "Salesforce Code Analyzer",
-            "properties": {
-                "codeAnalyzer.pMD.customConfigFile": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Replace Code Analyzer's default PMD config file, choose a custom file."
-                },
-                "codeAnalyzer.graphEngine.disableWarningViolations": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Suppress warning violations, such as those related to StripInaccessible READ access."
-                },
-                "codeAnalyzer.graphEngine.threadTimeout": {
-                    "type": "number",
-                    "default": 900000,
-                    "description": "After the thread timeout elapses, the path evaluation aborts. The default timeout is 900,000 milliseconds."
-                },
-                "codeAnalyzer.graphEngine.pathExpansionLimit": {
-                    "type": "number",
-                    "default": 0,
-                    "description": "An upper boundary to limit the complexity of code analyzed by Graph Engine. The default of 0 is a dynamically determined limit that's based on heap space. To learn more about heap space, see OutOfMemory errors in the Graph Engine documentation."
-                },
-                "codeAnalyzer.graphEngine.jvmArgs": {
-                    "type": "string",
-                    "description": "The Java Virtual Machine (JVM) arguments used to optimize Salesforce Graph Engine execution for your system."
-                },
+        "configuration": [{
+			"title": "General",
+			"properties": {
                 "codeAnalyzer.analyzeOnSave.enabled": {
                     "type": "boolean",
                     "default": false,
@@ -151,6 +127,53 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Scan files on open automatically."
+                },
+				"codeAnalyzer.apexGuru.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Discover critical problems and performance issues in your Apex code with ApexGuru, which analyzes your Apex files for you. This feature is in a closed pilot; contact your account representative to learn more."
+                }
+			}
+		}, {
+			"title": "Beta Code Analyzer",
+			"properties": {
+				"codeAnalyzer.enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables Code Analyzer v5."
+				},
+				"codeAnalyzer.ruleSelectors": {
+					"type": "string",
+					"default": "Recommended",
+					"description": "Specifies Rule Selectors to use during default execution."
+				}
+			}
+		}, {
+			"title": "Legacy Code Analyzer",
+			"properties": {
+				"codeAnalyzer.pMD.customConfigFile": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Replace Code Analyzer's default PMD config file, choose a custom file."
+                },
+				"codeAnalyzer.graphEngine.disableWarningViolations": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Suppress warning violations, such as those related to StripInaccessible READ access."
+                },
+				"codeAnalyzer.graphEngine.threadTimeout": {
+                    "type": "number",
+                    "default": 900000,
+                    "description": "After the thread timeout elapses, the path evaluation aborts. The default timeout is 900,000 milliseconds."
+                },
+				"codeAnalyzer.graphEngine.pathExpansionLimit": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "An upper boundary to limit the complexity of code analyzed by Graph Engine. The default of 0 is a dynamically determined limit that's based on heap space. To learn more about heap space, see OutOfMemory errors in the Graph Engine documentation."
+                },
+                "codeAnalyzer.graphEngine.jvmArgs": {
+                    "type": "string",
+                    "description": "The Java Virtual Machine (JVM) arguments used to optimize Salesforce Graph Engine execution for your system."
                 },
                 "codeAnalyzer.scanner.engines": {
                     "type": "string",
@@ -166,18 +189,13 @@
                     "type": "string",
                     "description": "The categories of rules to run. Specify multiple values as a comma-separated list. Run 'sf scanner rule list -e' in the terminal for the list of categories associated with a specific engine."
                 },
-                "codeAnalyzer.apexGuru.enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Discover critical problems and performance issues in your Apex code with ApexGuru, which analyzes your Apex files for you. This feature is in a closed pilot; contact your account representative to learn more."
-                },
                 "codeAnalyzer.partialGraphEngineScans.enabled": {
                     "type": "boolean",
                     "default": false,
                     "description": "Enables partial Salesforce Graph Engine scans on only the code you've modified since the initial full scan. (Beta)"
                 }
-            }
-        },
+			}
+		}],
         "menus": {
             "commandPalette": [
                 {

--- a/package.json
+++ b/package.json
@@ -145,8 +145,7 @@
 				"codeAnalyzer.ruleSelectors": {
 					"type": "string",
 					"default": "Recommended",
-					"markdownDescription": "Specifies Rule Selectors to use during default execution of Code Analyzer v5 (Beta). Use commas for unions (e.g., \"Security,Performance\") and colons for intersections (e.g., \"pmd:Security\").",
-					"description": "Specifies Rule Selectors to use during default execution of Code Analyzer v5 (Beta)."
+					"markdownDescription": "Specifies the default set of rules to use when executing Code Analyzer v5 (Beta). Specify the rules using their name, engine name, severity level, tag, or a combination. Use commas for unions (such as \"Security,Performance\") and colons for intersections (such as \"pmd:Security\" or \"eslint:3\")."
 				}
 			}
 		}, {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
         "configuration": [{
 			"title": "General",
 			"properties": {
+				"codeAnalyzerV5.enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "Use Code Analyzer v5 (Beta) instead of Code Analyzer v4."
+				},
                 "codeAnalyzer.analyzeOnSave.enabled": {
                     "type": "boolean",
                     "default": false,
@@ -135,64 +140,59 @@
                 }
 			}
 		}, {
-			"title": "Beta Code Analyzer",
+			"title": "Code Analyzer v5 (Beta)",
 			"properties": {
-				"codeAnalyzer.enabled": {
-					"type": "boolean",
-					"default": false,
-					"description": "Enables Code Analyzer v5."
-				},
 				"codeAnalyzer.ruleSelectors": {
 					"type": "string",
 					"default": "Recommended",
-					"description": "Specifies Rule Selectors to use during default execution."
+					"description": "Specifies Rule Selectors to use during default execution of Code Analyzer v5 (Beta)."
 				}
 			}
 		}, {
-			"title": "Legacy Code Analyzer",
+			"title": "Code Analyzer v4",
 			"properties": {
 				"codeAnalyzer.pMD.customConfigFile": {
                     "type": "string",
                     "default": "",
-                    "description": "Replace Code Analyzer's default PMD config file, choose a custom file."
+                    "description": "(v4 only) Replace Code Analyzer's default PMD config file, choose a custom file."
                 },
 				"codeAnalyzer.graphEngine.disableWarningViolations": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Suppress warning violations, such as those related to StripInaccessible READ access."
+                    "description": "(v4 only) Suppress warning violations, such as those related to StripInaccessible READ access."
                 },
 				"codeAnalyzer.graphEngine.threadTimeout": {
                     "type": "number",
                     "default": 900000,
-                    "description": "After the thread timeout elapses, the path evaluation aborts. The default timeout is 900,000 milliseconds."
+                    "description": "(v4 only) After the thread timeout elapses, the path evaluation aborts. The default timeout is 900,000 milliseconds."
                 },
 				"codeAnalyzer.graphEngine.pathExpansionLimit": {
                     "type": "number",
                     "default": 0,
-                    "description": "An upper boundary to limit the complexity of code analyzed by Graph Engine. The default of 0 is a dynamically determined limit that's based on heap space. To learn more about heap space, see OutOfMemory errors in the Graph Engine documentation."
+                    "description": "(v4 only) An upper boundary to limit the complexity of code analyzed by Graph Engine. The default of 0 is a dynamically determined limit that's based on heap space. To learn more about heap space, see OutOfMemory errors in the Graph Engine documentation."
                 },
                 "codeAnalyzer.graphEngine.jvmArgs": {
                     "type": "string",
-                    "description": "The Java Virtual Machine (JVM) arguments used to optimize Salesforce Graph Engine execution for your system."
+                    "description": "(v4 only) The Java Virtual Machine (JVM) arguments used to optimize Salesforce Graph Engine execution for your system."
                 },
                 "codeAnalyzer.scanner.engines": {
                     "type": "string",
                     "default": "pmd,retire-js,eslint-lwc",
-                    "description": "The engines to run. Specify multiple values as a comma-separated list. Possible values are pmd, pmd-appexchange, retire-js, eslint, eslint-lwc, and eslint-typescript."
+                    "description": "(v4 only) The engines to run. Specify multiple values as a comma-separated list. Possible values are pmd, pmd-appexchange, retire-js, eslint, eslint-lwc, and eslint-typescript."
                 },
                 "codeAnalyzer.normalizeSeverity.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Output normalized severity (high, moderate, low) and engine-specific severity across all engines."
+                    "description": "(v4 only) Output normalized severity (high, moderate, low) and engine-specific severity across all engines."
                 },
                 "codeAnalyzer.rules.category": {
                     "type": "string",
-                    "description": "The categories of rules to run. Specify multiple values as a comma-separated list. Run 'sf scanner rule list -e' in the terminal for the list of categories associated with a specific engine."
+                    "description": "(v4 only) The categories of rules to run. Specify multiple values as a comma-separated list. Run 'sf scanner rule list -e' in the terminal for the list of categories associated with a specific engine."
                 },
                 "codeAnalyzer.partialGraphEngineScans.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enables partial Salesforce Graph Engine scans on only the code you've modified since the initial full scan. (Beta)"
+                    "description": "(v4 only) Enables partial Salesforce Graph Engine scans on only the code you've modified since the initial full scan. (Beta)"
                 }
 			}
 		}],

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "configuration": [{
 			"title": "General",
 			"properties": {
-				"codeAnalyzerV5.enabled": {
+				"codeAnalyzer.enableV5": {
 					"type": "boolean",
 					"default": false,
 					"description": "Use Code Analyzer v5 (Beta) instead of Code Analyzer v4."

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
 				"codeAnalyzer.ruleSelectors": {
 					"type": "string",
 					"default": "Recommended",
+					"markdownDescription": "Specifies Rule Selectors to use during default execution of Code Analyzer v5 (Beta). Use commas for unions (e.g., \"Security,Performance\") and colons for intersections (e.g., \"pmd:Security\").",
 					"description": "Specifies Rule Selectors to use during default execution of Code Analyzer v5 (Beta)."
 				}
 			}


### PR DESCRIPTION
This PR does the following:
- Regroups our existing settings into "General" and "Code Analyzer v4" groups.
  - Adds "(v4 only)" to the description of all v4 settings.
- Adds a new "Enable Code Analyzer v5" boolean setting to the "General" section.
- Adds a "Code Analyzer v5 (Beta)" section with a "Rule Selectors" setting.

Screenshot depicting the new settings and their organization:
![Screenshot 2025-01-29 at 11 35 17 AM](https://github.com/user-attachments/assets/84609657-5385-47ab-aeb7-ac762f9b20b6)
