### PR TITLE
FIX: @W-18088088@: Fix a few low hanging bugs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -243,6 +243,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
             return;
         }
 
+        logger.debug(`Agentforce Fix Diff:\n` + 
+            `=== ORIGINAL CODE ===:\n${fixSuggestion.getOriginalCodeToBeFixed()}\n\n` +
+            `=== FIXED CODE ===:\n${fixSuggestion.getFixedCode()}`);
+
         diagnosticManager.clearDiagnostic(document.uri, diagnostic);
 
         // TODO: We really need to either improve or replace the CodeGenie unified diff tool. Ideally, we would be
@@ -254,13 +258,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
         const commandSource: string = Constants.QF_COMMAND_A4D_FIX;
         await unifiedDiffActions.createDiff(commandSource, document, fixSuggestion.getFixedDocumentCode());
 
-        // We should consider a better way to display the explanation associated with the fix.
         if (fixSuggestion.hasExplanation()) {
-            logger.log(messages.agentforce.explanationOfFix(indent(fixSuggestion.getExplanation())));
+            vscode.window.showInformationMessage(messages.agentforce.explanationOfFix(fixSuggestion.getExplanation()));
         }
-
-        logger.trace(`=== ORIGINAL CODE ===:\n${fixSuggestion.getOriginalCodeToBeFixed()}\n\n` +
-            `=== FIXED CODE ===:\n${fixSuggestion.getFixedCode()}`);
     });
 
 
@@ -361,8 +361,3 @@ async function establishVariableInContext(varUsedInPackageJson: string, getValue
         await vscode.commands.executeCommand('setContext', varUsedInPackageJson, await getValueFcn());
     });
 }
-
-export function indent(value: string, indentation = '    '): string {
-    return indentation + value.replace(/\n/g, `\n${indentation}`);
-}
-

--- a/src/lib/agentforce/supported-rules.ts
+++ b/src/lib/agentforce/supported-rules.ts
@@ -68,7 +68,7 @@ export const A4D_SUPPORTED_RULES: Map<string, RuleInfo> = new Map([
     }],
     ['MethodWithSameNameAsEnclosingClass', {
         description: 'Non-constructor methods should not have the same name as the enclosing class.',
-        violationContextScope: ViolationContextScope.ViolationScope
+        violationContextScope: ViolationContextScope.ClassScope
     }],
     ['OverrideBothEqualsAndHashcode', {
         description: 'Override both `public Boolean equals(Object obj)`, and `public Integer hashCode()`, or override neither. Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass. This is especially important when Using Custom Types in Map Keys and Sets.',
@@ -76,7 +76,7 @@ export const A4D_SUPPORTED_RULES: Map<string, RuleInfo> = new Map([
     }],
     ['TestMethodsMustBeInTestClasses', {
         description: 'Test methods marked as a testMethod or annotated with @IsTest, but not residing in a test class should be moved to a proper class or have the @IsTest annotation added to the class. Support for tests inside functional classes was removed in Spring-13 (API Version 27.0), making classes that violate this rule fail compile-time. This rule is mostly usable when dealing with legacy code.',
-        violationContextScope: ViolationContextScope.ViolationScope
+        violationContextScope: ViolationContextScope.ClassScope
     }],
 
 

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -133,6 +133,11 @@ export class DiagnosticManagerImpl implements DiagnosticManager {
         // This is an interim fix to handle ApexSharingViolations and can be removed once PMD fixes PMD fixes the bug: https://github.com/pmd/pmd/issues/5511
         if (convertible.rule === 'ApexSharingViolations' && primaryLocation.endLine && primaryLocation.endLine !== primaryLocation.startLine) {
             primaryLocationRange = this.convertToRangeForApexSharingViolations(primaryLocation);
+        } else if (convertible.rule === 'ApexDoc' || convertible.rule === 'ExcessiveParameterList') {
+             // See https://github.com/pmd/pmd/issues/5614 and https://github.com/pmd/pmd/issues/5616
+            primaryLocationRange = this.convertToRange(primaryLocation);
+            primaryLocationRange = new vscode.Range(primaryLocationRange.start.line, primaryLocationRange.start.character, 
+                primaryLocationRange.start.line, Number.MAX_SAFE_INTEGER);
         } else {
             primaryLocationRange = this.convertToRange(primaryLocation);
         }
@@ -201,7 +206,6 @@ export class DiagnosticManagerImpl implements DiagnosticManager {
     private convertToRangeForApexSharingViolations({ startLine, startColumn }: DiagnosticConvertibleLocation): vscode.Range {
         const start = new vscode.Position(Math.max(startLine - 1, 0), Math.max(startColumn - 1, 0));
         const end = new vscode.Position(start.line, Number.MAX_SAFE_INTEGER);
-
         return new vscode.Range(start, end);
     }
 }

--- a/src/lib/fix-suggestion.ts
+++ b/src/lib/fix-suggestion.ts
@@ -15,6 +15,9 @@ export type CodeFixData = {
     fixedCode: string
 }
 
+
+// IMPORTANT: Currently the CodeFixData contains the document and not a copy of the original document code, so the methods in this class
+// assume that you have not modified the document. Otherwise, the rangeToBeFixed will be associated with the newly modified document.
 export class FixSuggestion {
     readonly codeFixData: CodeFixData;
     private readonly explanation?: string;

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -21,9 +21,9 @@ export const messages = {
     },
     agentforce: {
         a4dQuickFixUnavailable: "The ability to fix violations with Agentforce is unavailable since a compatible 'Agentforce for Developers' extension was not found or activated. To enable this functionality, please install the 'Agentforce for Developers' extension and restart VS Code.",
-        fixViolationWithA4D: (ruleName: string) => `Fix ${ruleName} using Agentforce. (Beta)`,
+        fixViolationWithA4D: (ruleName: string) => `Fix '${ruleName}' using Agentforce. (Beta)`,
         failedA4DResponse: "Unable to receive code fix suggestion from Agentforce.",
-        explanationOfFix: (explanation: string) => `Explanation of the fix supplied by Agentforce:\n${explanation}`
+        explanationOfFix: (explanation: string) => `Agentforce Fix Explanation: ${explanation}`
     },
     apexGuru: {
         progress: {
@@ -46,8 +46,8 @@ export const messages = {
         existingDfaRunText: "A Salesforce Graph Engine analysis is already running. Cancel it by clicking in the Status Bar.",
     },
     fixer: {
-        suppressOnLine: "Suppress violations on this line.",
-        suppressOnClass: "Suppress violations on this class.",
+        suppressPMDViolationsOnLine: "Suppress all PMD violations on this line.",
+        suppressPmdViolationsOnClass: (ruleName?: string) => ruleName ? `Suppress '${ruleName}' on this class.` : `Suppress all PMD violations on this class.`,
         fixWithApexGuruSuggestions: "Insert ApexGuru suggestions."
     },
     diagnostics: {

--- a/src/shared/UnifiedDiff.ts
+++ b/src/shared/UnifiedDiff.ts
@@ -513,7 +513,7 @@ export class VSCodeUnifiedDiff implements vscode.CodeLensProvider, vscode.CodeAc
       diff.getHunks().length === 0 ||
       (diff.getHunks().length === 1 && diff.getHunks()[0].type === DiffType.Unmodified)
     ) {
-      vscode.window.showInformationMessage('Ask CodeGenie: No changes to diff.');
+      vscode.window.showInformationMessage('Agentforce Fix: No changes to diff.');
       return;
     }
 


### PR DESCRIPTION
Fixes:
* To avoid us using Trace debug level for now (since it causes some issues with the core extension activating) I switched the Agentforce Fix Diff logging to use debug log instead. Also I made sure it was robust but displaying the original code before we modify the document.
* When the LLM comes back with an explaination, now we show it in an information window instead of just logging it.
* 2 rules needed to switch to ClassScope
* ApexDoc and ExcessiveParameterList are really noisy rules because they highlight the world... making them only hightlight on a single line now
* Updated the class level suppression to show the rule name now so that it doesn't look like have a ton of redundant quick fix suggestions, since they truly are different
* From unified diff, taking out "Ask CodeGenie" in favor of "Agentforce Fix"