### PR TITLE
FIX: @W-18195076@: Emergency patch for 1.5.x release to fix onOpen issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "color": "#ECECEC",
         "theme": "light"
     },
-    "version": "1.5.0",
+    "version": "1.5.1",
     "publisher": "salesforce",
     "license": "BSD-3-Clause",
     "engines": {

--- a/src/test/legacy/scanner.test.ts
+++ b/src/test/legacy/scanner.test.ts
@@ -344,7 +344,7 @@ suite('ScanRunner', () => {
 
         test('Adds process Id to the cache', () => {
             // ===== SETUP =====
-            const args:string[] = [];
+            const args:string[] = ['scanner', 'run', 'dfa', '--target', 'doesNotMatter', '--json'];
             const scanner = new ScanRunner();
             void context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, undefined);
 


### PR DESCRIPTION
There is a major bug that has existed for quite a while actually that is now showing up due to A4D Extension calling vscode.workspace.openTextDocument even though it doesn't open a file in the editor.

So this change - makes our "Analyze On Open" feature react only to changes to the active text editor. But we don't want to scan each time a user changes focus between tabs, so I added a ScanMonitor to keep track of if a file has been scanned or not yet. Anytime the user saves a file then we remove it from the "alreadyBeenScanned" list so that it can be scanned again if the user re-focuses the window. This was the only approach that seemed to work well and reliably. All other listeners had race conditions and other issues... but this effectively solves the problem.