### PR TITLE
CHANGE: @W-18246414@ Verify that diff can be shown before calling LLM

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
         "showcoverage-legacy": "open ./coverage/legacy/lcov-report/index.html"
     },
     "activationEvents": [
-        "workspaceContains:sfdx-project.json"
+        "workspaceContains:sfdx-project.json",
+        "onLanguage:apex"
     ],
     "main": "./out/extension.js",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,7 +261,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
     // =================================================================================================================
     // ==  Unified Diff Service
     // =================================================================================================================
-    const unifiedDiffService: UnifiedDiffService = new UnifiedDiffServiceImpl(settingsManager);
+    const unifiedDiffService: UnifiedDiffService = new UnifiedDiffServiceImpl(settingsManager, display);
     unifiedDiffService.register();
     context.subscriptions.push(unifiedDiffService);
 

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -70,11 +70,14 @@ export class CodeAnalyzerDiagnostic extends vscode.Diagnostic {
         }
         const diagnostic: CodeAnalyzerDiagnostic = new CodeAnalyzerDiagnostic(violation);
 
-        // Some violation's have ranges that are too noisy, so for now we manually fix them here while we wait on:
-        // - https://github.com/pmd/pmd/issues/5511 for 'ApexSharingViolations'
-        // - https://github.com/pmd/pmd/issues/5614 for 'ApexDoc'
-        // - https://github.com/pmd/pmd/issues/5616 for 'ExcessiveParameterList'
-        if (['ApexDoc', 'ApexSharingViolations', 'ExcessiveParameterList'].includes(violation.rule)) {
+        // Some violations have ranges that are too noisy, so for now we manually fix them here while we wait on PMD to fix them:
+        const rulesToReduceViolationsToSingleLine: string[] = [
+            'ApexDoc',                                      // https://github.com/pmd/pmd/issues/5614
+            'ApexUnitTestMethodShouldHaveIsTestAnnotation', // https://github.com/pmd/pmd/issues/5669
+            'AvoidGlobalModifer',                           // https://github.com/pmd/pmd/issues/5668
+            'ApexSharingViolations',                        // https://github.com/pmd/pmd/issues/5511
+            'ExcessiveParameterList'];                      // https://github.com/pmd/pmd/issues/5616
+        if (rulesToReduceViolationsToSingleLine.includes(violation.rule)) {
             diagnostic.range = new vscode.Range(diagnostic.range.start.line, diagnostic.range.start.character,
                 diagnostic.range.start.line, Number.MAX_SAFE_INTEGER);
         }

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -6,10 +6,15 @@ export type ProgressEvent = {
     increment?: number;
 };
 
+export type DisplayButton = {
+    text: string
+    callback: ()=>void
+}
+
 export interface Display {
     displayProgress(progressEvent: ProgressEvent): void;
     displayInfo(infoMsg: string): void;
-    displayWarning(warnMsg: string): void;
+    displayWarning(warnMsg: string, ...buttons: DisplayButton[]): void;
     displayError(errorMsg: string): void;
 }
 
@@ -35,9 +40,13 @@ export class VSCodeDisplay implements Display {
         this.logger.log(infoMsg);
     }
 
-    displayWarning(warnMsg: string): void {
-        // Not waiting for promise because we didn't add buttons and don't care if user ignores the message.
-        void vscode.window.showWarningMessage(warnMsg);
+    displayWarning(warnMsg: string, ...buttons: DisplayButton[]): void {
+        void vscode.window.showWarningMessage(warnMsg, ...buttons.map(b => b.text)).then(selectedText => {
+            const selectedButton: DisplayButton = buttons.find(b => b.text === selectedText);
+            if(selectedButton) {
+                selectedButton.callback();
+            }
+        });
         this.logger.warn(warnMsg);
     }
 

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -30,7 +30,7 @@ export const messages = {
         noFixSuggested: "No fix was suggested."
     },
     unifiedDiff: {
-        mustAcceptOrRejectDiffFirst: "You must accept/reject the existing diff in this file before performing this action.",
+        mustAcceptOrRejectDiffFirst: "You must accept or reject all changes before performing this action.",
         editorCodeLensMustBeEnabled: "This action requires the 'Editor: Code Lens' setting to be enabled."
     },
     apexGuru: {

--- a/src/lib/unified-diff-service.ts
+++ b/src/lib/unified-diff-service.ts
@@ -2,12 +2,33 @@ import * as vscode from 'vscode';
 import {UnifiedDiff, CodeGenieUnifiedDiffService} from "../shared/UnifiedDiff";
 import {SettingsManager} from "./settings";
 import {messages} from "./messages";
+import {Display} from "./display";
 
 export interface UnifiedDiffService extends vscode.Disposable {
+    /**
+     * Function called during activation of the extension to register the service with VS Code
+     */
     register(): void;
-    hasDiff(document: vscode.TextDocument): boolean
+
+    /**
+     * Verifies whether a unified diff can be shown for the document.
+     *
+     * If a diff can't be shown, then the UnifiedDiffService should display any warning or error message boxes before
+     * returning false. Otherwise, if a diff can be shown then return true.
+     *
+     * @param document TextDocument to display unified diff
+     */
+    verifyCanShowDiff(document: vscode.TextDocument): boolean
+
+    /**
+     * Shows a unified diff on a document
+     *
+     * @param document TextDocument to display unified diff
+     * @param newCode the new code that will replace the entire current document's code
+     * @param acceptCallback function to call when a user accepts the unified diff
+     * @param rejectCallback function to call when a user rejects the unified diff
+     */
     showDiff(document: vscode.TextDocument, newCode: string, acceptCallback: ()=>Promise<void>, rejectCallback: ()=>Promise<void>): Promise<void>
-    clearDiff(document: vscode.TextDocument): Promise<void>;
 }
 
 /**
@@ -16,10 +37,12 @@ export interface UnifiedDiffService extends vscode.Disposable {
 export class UnifiedDiffServiceImpl implements UnifiedDiffService {
     private readonly codeGenieUnifiedDiffService: CodeGenieUnifiedDiffService;
     private readonly settingsManager: SettingsManager;
+    private readonly display: Display;
 
-    constructor(settingsManager: SettingsManager) {
+    constructor(settingsManager: SettingsManager, display: Display) {
         this.codeGenieUnifiedDiffService = new CodeGenieUnifiedDiffService();
         this.settingsManager = settingsManager;
+        this.display = display;
     }
 
     register(): void {
@@ -30,32 +53,37 @@ export class UnifiedDiffServiceImpl implements UnifiedDiffService {
         this.codeGenieUnifiedDiffService.dispose();
     }
 
-    hasDiff(document: vscode.TextDocument): boolean {
-        return this.codeGenieUnifiedDiffService.hasDiff(document);
+    verifyCanShowDiff(document: vscode.TextDocument): boolean {
+        if (this.codeGenieUnifiedDiffService.hasDiff(document)) {
+            void this.codeGenieUnifiedDiffService.focusOnDiff(
+                this.codeGenieUnifiedDiffService.getDiff(document)
+            );
+            this.display.displayWarning(messages.unifiedDiff.mustAcceptOrRejectDiffFirst);
+            return false;
+        } else if (!this.settingsManager.getEditorCodeLensEnabled()) {
+            this.display.displayWarning(messages.unifiedDiff.editorCodeLensMustBeEnabled,
+                {
+                    text: messages.buttons.showSettings,
+                    callback: (): void => {
+                        const settingUri: vscode.Uri = vscode.Uri.parse('vscode://settings/editor.codeLens');
+                        void vscode.commands.executeCommand('vscode.open', settingUri);
+                    }
+                });
+            return false;
+        }
+        return true;
     }
 
     async showDiff(document: vscode.TextDocument, newCode: string, acceptCallback: ()=>Promise<void>, rejectCallback: ()=>Promise<void>): Promise<void> {
-        this.validateCanShowDiff();
         const diff = new UnifiedDiff(document, newCode);
         diff.allowAbilityToAcceptOrRejectIndividualHunks = false;
         diff.acceptAllCallback = acceptCallback;
         diff.rejectAllCallback = rejectCallback;
-        await this.codeGenieUnifiedDiffService.showUnifiedDiff(diff);
-    }
-
-    async clearDiff(document: vscode.TextDocument): Promise<void> {
-        await this.codeGenieUnifiedDiffService.revertUnifiedDiff(document);
-    }
-
-    private validateCanShowDiff(): void {
-        if (!this.settingsManager.getEditorCodeLensEnabled()) {
-            void vscode.window.showWarningMessage(messages.unifiedDiff.editorCodeLensMustBeEnabled, messages.buttons.showSettings).then(selection => {
-                if (selection === messages.buttons.showSettings) {
-                    const settingUri = vscode.Uri.parse('vscode://settings/editor.codeLens');
-                    vscode.commands.executeCommand('vscode.open', settingUri);
-                }
-            });
-            throw new Error(messages.unifiedDiff.editorCodeLensMustBeEnabled);
+        try {
+            await this.codeGenieUnifiedDiffService.showUnifiedDiff(diff);
+        } catch (err) {
+            await this.codeGenieUnifiedDiffService.revertUnifiedDiff(document);
+            throw err;
         }
     }
 }

--- a/src/test/unit/lib/unified-diff-service.test.ts
+++ b/src/test/unit/lib/unified-diff-service.test.ts
@@ -1,0 +1,127 @@
+import * as vscode from "vscode"; // The vscode module is mocked out. See: scripts/setup.jest.ts
+
+import {CodeGenieUnifiedDiffService, UnifiedDiff} from "../../../shared/UnifiedDiff";
+import {createTextDocument} from "jest-mock-vscode";
+import * as stubs from "../stubs";
+import {UnifiedDiffService, UnifiedDiffServiceImpl} from "../../../lib/unified-diff-service";
+import {messages} from "../../../lib/messages";
+
+describe('Tests for the UnifiedDiffServiceImpl class', () => {
+    const sampleUri: vscode.Uri = vscode.Uri.file('/some/file.cls');
+    const sampleDocument: vscode.TextDocument = createTextDocument(sampleUri, 'some\nsample content', 'apex');
+
+    let settingsManager: stubs.StubSettingsManager;
+    let display: stubs.SpyDisplay;
+    let unifiedDiffService: UnifiedDiffService;
+
+    beforeEach(() => {
+        settingsManager = new stubs.StubSettingsManager();
+        display = new stubs.SpyDisplay();
+        unifiedDiffService = new UnifiedDiffServiceImpl(settingsManager, display);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('When register method is called, it calls through to CodeGenieUnifiedDiffService.register', () => {
+        const registerSpy = jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'register').mockImplementation((): void => {});
+
+        unifiedDiffService.register();
+
+        expect(registerSpy).toHaveBeenCalled();
+    });
+
+    it('When dispose method is called, it calls through to CodeGenieUnifiedDiffService.dispose', () => {
+        const disposeSpy = jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'dispose').mockImplementation((): void => {});
+
+        unifiedDiffService.dispose();
+
+        expect(disposeSpy).toHaveBeenCalled();
+    });
+
+    describe('Tests for the verifyCanShowDiff method ', () => {
+        it('When CodeGenieUnifiedDiffService has a diff for a given document, then verifyCanShowDiff will focus on the diff, display a warning msg box, and return false', () => {
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'hasDiff').mockImplementation((): boolean => {
+                return true;
+            });
+            const focusOnDiffSpy = jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'focusOnDiff').mockImplementation((_diff: UnifiedDiff): Promise<void> => {
+                return Promise.resolve();
+            });
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'getDiff').mockImplementation((document: vscode.TextDocument): UnifiedDiff => {
+                return new UnifiedDiff(document, 'someNewCode');
+            });
+
+            const result: boolean = unifiedDiffService.verifyCanShowDiff(sampleDocument);
+
+            expect(focusOnDiffSpy).toHaveBeenCalled();
+            expect(display.displayWarningCallHistory).toHaveLength(1);
+            expect(display.displayWarningCallHistory[0].msg).toEqual(messages.unifiedDiff.mustAcceptOrRejectDiffFirst);
+            expect(result).toEqual(false);
+        });
+
+        it('When editor.codeLens setting is not enabled, then verifyCanShowDiff will display a warning msg box and return false', () => {
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'hasDiff').mockImplementation((): boolean => {
+                return false;
+            });
+            settingsManager.getEditorCodeLensEnabledReturnValue = false;
+
+            const result: boolean = unifiedDiffService.verifyCanShowDiff(sampleDocument);
+
+            expect(display.displayWarningCallHistory).toHaveLength(1);
+            expect(display.displayWarningCallHistory[0].msg).toEqual(messages.unifiedDiff.editorCodeLensMustBeEnabled);
+            expect(result).toEqual(false);
+        });
+
+        it('When CodeGenieUnifiedDiffService does not have diff and editor.codeLens setting is enabled, then verifyCanShowDiff returns true', () => {
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'hasDiff').mockImplementation((): boolean => {
+                return false;
+            });
+            settingsManager.getEditorCodeLensEnabledReturnValue = true;
+
+            const result: boolean = unifiedDiffService.verifyCanShowDiff(sampleDocument);
+
+            expect(display.displayWarningCallHistory).toHaveLength(0);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('Tests for the showDiff method', () => {
+        const dummyAcceptCallback: ()=>Promise<void> = () => {
+            return Promise.resolve();
+        };
+        const dummyRejectCallback: ()=>Promise<void> = () => {
+            return Promise.resolve();
+        };
+
+        it('When showDiff is called, then CodeGenieUnifiedDiffService.showUnifiedDiff receives the correct diff with callbacks', async () => {
+            let diffReceived: UnifiedDiff | undefined;
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'showUnifiedDiff').mockImplementation((diff: UnifiedDiff): Promise<void> => {
+                diffReceived = diff;
+                return Promise.resolve();
+            });
+
+            await unifiedDiffService.showDiff(sampleDocument, 'dummyNewCode', dummyAcceptCallback, dummyRejectCallback);
+
+            expect(diffReceived).toBeDefined();
+            expect(diffReceived.getTargetCode()).toEqual('dummyNewCode');
+            expect(diffReceived.allowAbilityToAcceptOrRejectIndividualHunks).toEqual(false);
+            expect(diffReceived.acceptAllCallback).toEqual(dummyAcceptCallback);
+            expect(diffReceived.rejectAllCallback).toEqual(dummyRejectCallback);
+        });
+
+        it('When showDiff is called but CodeGenieUnifiedDiffService.showUnifiedDiff errors, then we revert the unified diff and rethrow the error', async () => {
+            jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'showUnifiedDiff').mockImplementation((_diff: UnifiedDiff): Promise<void> => {
+                throw new Error('some error from showUnifiedDiff');
+            });
+            const revertUnifiedDiffSpy = jest.spyOn(CodeGenieUnifiedDiffService.prototype, 'revertUnifiedDiff').mockImplementation((_document: vscode.TextDocument): Promise<void> => {
+                return Promise.resolve();
+            });
+
+            await expect(unifiedDiffService.showDiff(sampleDocument, 'dummyNewCode', dummyAcceptCallback, dummyRejectCallback))
+                .rejects.toThrow('some error from showUnifiedDiff');
+
+            expect(revertUnifiedDiffSpy).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/test/unit/stubs.ts
+++ b/src/test/unit/stubs.ts
@@ -7,6 +7,7 @@ import {Display, ProgressEvent} from "../../lib/display";
 import {UnifiedDiffService} from "../../lib/unified-diff-service";
 import {TextDocument} from "vscode";
 import {FixSuggester, FixSuggestion} from "../../lib/fix-suggestion";
+import {SettingsManager} from "../../lib/settings";
 
 
 export class SpyTelemetryService implements TelemetryService {
@@ -159,11 +160,11 @@ export class SpyUnifiedDiffService implements UnifiedDiffService {
         // no op
     }
 
-    hasDiffReturnValue: boolean = false;
-    hasDiffCallHistory: { document: TextDocument }[] = [];
-    hasDiff(document: TextDocument): boolean {
-        this.hasDiffCallHistory.push({document});
-        return this.hasDiffReturnValue;
+    verifyCanShowDiffReturnValue: boolean = true;
+    verifyCanShowDiffCallHistory: { document: TextDocument }[] = [];
+    verifyCanShowDiff(document: TextDocument): boolean {
+        this.verifyCanShowDiffCallHistory.push({document});
+        return this.verifyCanShowDiffReturnValue;
     }
 
     showDiffCallHistory: {
@@ -174,12 +175,6 @@ export class SpyUnifiedDiffService implements UnifiedDiffService {
     }[] = [];
     showDiff(document: TextDocument, newCode: string, acceptCallback: () => Promise<void>, rejectCallback: () => Promise<void>): Promise<void> {
         this.showDiffCallHistory.push({document, newCode, acceptCallback, rejectCallback});
-        return Promise.resolve();
-    }
-
-    clearDiffCallHistory: {document: TextDocument}[] = [];
-    clearDiff(document: TextDocument): Promise<void> {
-        this.clearDiffCallHistory.push({document});
         return Promise.resolve();
     }
 }
@@ -193,17 +188,12 @@ export class ThrowingUnifiedDiffService implements UnifiedDiffService {
         // no-op
     }
 
-    hasDiff(_document: TextDocument): boolean {
-        return false;
+    verifyCanShowDiff(_document: TextDocument): boolean {
+        return true;
     }
 
     showDiff(_document: TextDocument, _newCode: string, _acceptCallback: () => Promise<void>, _rejectCallback: () => Promise<void>): Promise<void> {
         throw new Error('Error thrown from: showDiff');
-    }
-
-    clearDiff(_document: TextDocument): Promise<void> {
-        // no-op
-        return Promise.resolve();
     }
 }
 
@@ -221,4 +211,88 @@ export class ThrowingFixSuggester implements FixSuggester {
     suggestFix(_document: TextDocument, _diagnostic: CodeAnalyzerDiagnostic): Promise<FixSuggestion | null> {
         throw new Error('Error thrown from: suggestFix');
     }
+}
+
+
+export class StubSettingsManager implements SettingsManager {
+
+    // =================================================================================================================
+    // ==== General Settings
+    // =================================================================================================================
+    getAnalyzeOnOpenReturnValue: boolean = false;
+    getAnalyzeOnOpen(): boolean {
+        return this.getAnalyzeOnOpenReturnValue;
+    }
+
+    getAnalyzeOnSaveReturnValue: boolean = false;
+    getAnalyzeOnSave(): boolean {
+        return this.getAnalyzeOnSaveReturnValue;
+    }
+
+    getApexGuruEnabledReturnValue: boolean = false;
+    getApexGuruEnabled(): boolean {
+        return this.getApexGuruEnabledReturnValue;
+    }
+
+    getCodeAnalyzerUseV4DeprecatedReturnValue: boolean = false;
+    getCodeAnalyzerUseV4Deprecated(): boolean {
+        return this.getCodeAnalyzerUseV4DeprecatedReturnValue;
+    }
+
+    setCodeAnalyzerUseV4Deprecated(value: boolean): void {
+        this.getCodeAnalyzerUseV4DeprecatedReturnValue = value;
+    }
+
+    // =================================================================================================================
+    // ==== v5 Settings
+    // =================================================================================================================
+    getCodeAnalyzerConfigFileReturnValue: string = '';
+    getCodeAnalyzerConfigFile(): string {
+        return this.getCodeAnalyzerConfigFileReturnValue;
+    }
+
+    getCodeAnalyzerRuleSelectorsReturnValue: string = 'Recommended';
+    getCodeAnalyzerRuleSelectors(): string {
+        return this.getCodeAnalyzerRuleSelectorsReturnValue;
+    }
+
+    // =================================================================================================================
+    // ==== v4 Settings (Deprecated)
+    // =================================================================================================================
+    getPmdCustomConfigFile(): string {
+        throw new Error("Method not implemented.");
+    }
+    getGraphEngineDisableWarningViolations(): boolean {
+        throw new Error("Method not implemented.");
+    }
+    getGraphEngineThreadTimeout(): number {
+        throw new Error("Method not implemented.");
+    }
+    getGraphEnginePathExpansionLimit(): number {
+        throw new Error("Method not implemented.");
+    }
+    getGraphEngineJvmArgs(): string {
+        throw new Error("Method not implemented.");
+    }
+    getEnginesToRun(): string {
+        throw new Error("Method not implemented.");
+    }
+    getNormalizeSeverityEnabled(): boolean {
+        throw new Error("Method not implemented.");
+    }
+    getRulesCategory(): string {
+        throw new Error("Method not implemented.");
+    }
+    getSfgePartialSfgeRunsEnabled(): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    // =================================================================================================================
+    // ==== Other Settings that we may depend on
+    // =================================================================================================================
+    getEditorCodeLensEnabledReturnValue: boolean = true;
+    getEditorCodeLensEnabled(): boolean {
+        return this.getEditorCodeLensEnabledReturnValue;
+    }
+
 }


### PR DESCRIPTION
* To respond to recent feedback, I now make it so that A4D Quick Fix doesn't call the LLM until after we have validated that a unified diff can be shown. This saves us from doing unnecessary work.
* Also, I improved a few more things:
** When no fix is suggested from A4D because it returns the exact same code, then we display "No fix suggested" and prevent unified diff tool from doing unnecessary work.
** When a user attempts to edit a file or attempts to perform another A4D quick fix action when an existing diff still exists, then we focus to the diff while showing the warning to make it easy for the user to find it.
** Added in a full test file for our UnifiedDiffServiceImpl layer.