### PR TITLE
CHANGE: @W-19053762@ Remove Scanner (v4) Settings Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "o11yUploadEndpoint": "https://794testsite.my.site.com/byolwr/webruntime/log/metrics",
     "enableO11y": "true",
     "bugs": {
-        "url": "https://github.com/forcedotcom/sfdx-code-analyzer-vscode/issues"
+        "url": "https://github.com/forcedotcom/code-analyzer/issues"
     },
     "repository": {
         "url": "https://github.com/forcedotcom/sfdx-code-analyzer-vscode"
@@ -109,20 +109,12 @@
                 "title": "SFDX: Scan Selected Files or Folders with Code Analyzer"
             },
             {
-                "command": "sfca.runDfaOnSelectedMethod",
-                "title": "SFDX: Scan Selected Method with Graph Engine Path-Based Analysis"
-            },
-            {
                 "command": "sfca.removeDiagnosticsOnActiveFile",
                 "title": "SFDX: Clear Code Analyzer Violations from Current File"
             },
             {
                 "command": "sfca.removeDiagnosticsOnSelectedFile",
                 "title": "SFDX: Clear Code Analyzer Violations from Selected Files or Folders"
-            },
-            {
-                "command": "sfca.runDfa",
-                "title": "SFDX: Scan Project with Graph Engine Path-Based Analysis"
             },
             {
                 "command": "sfca.runApexGuruAnalysisOnSelectedFile",
@@ -151,16 +143,11 @@
                         "type": "boolean",
                         "default": false,
                         "description": "(Pilot) Discover critical problems and performance issues in your Apex code with ApexGuru, which analyzes your Apex files for you. This feature is in a closed pilot; contact your account representative to learn more."
-                    },
-                    "codeAnalyzer.Use v4 (Deprecated)": {
-                        "type": "boolean",
-                        "default": false,
-                        "markdownDescription": "Use Code Analyzer v4 (Deprecated) instead of Code Analyzer v5.\n\nWe no longer support Code Analyzer v4 and will soon remove this setting. We highly recommend that you use [Code Analyzer v5](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/code-analyzer.html) instead. Selecting this setting ignores the Code Analyzer v5 settings and uses the v4 settings instead.\n\nIf you have having trouble switching to v5, create an [issue](https://github.com/forcedotcom/sfdx-code-analyzer-vscode/issues)."
                     }
                 }
             },
             {
-                "title": "Code Analyzer v5",
+                "title": "Configuration",
                 "properties": {
                     "codeAnalyzer.configFile": {
                         "type": "string",
@@ -170,55 +157,7 @@
                     "codeAnalyzer.ruleSelectors": {
                         "type": "string",
                         "default": "Recommended",
-                        "markdownDescription": "Selection of rules used to scan your code with Code Analyzer v5.\n\nSelect rules using their name, engine name, severity level, tag, or a combination. Use commas for unions (such as \"Security,Performance\") and colons for intersections (such as \"pmd:Security\" or \"eslint:3\").\n\nThis setting is equivalent to the `--rule-selector` flag of the CLI commands. See [examples](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_code-analyzer_commands_unified.htm#cli_reference_code-analyzer_rules_unified)."
-                    }
-                }
-            },
-            {
-                "title": "Code Analyzer v4 (Deprecated)",
-                "properties": {
-                    "codeAnalyzer.pMD.customConfigFile": {
-                        "type": "string",
-                        "default": "",
-                        "description": "(v4 only) Replace Code Analyzer's default PMD config file, choose a custom file."
-                    },
-                    "codeAnalyzer.graphEngine.disableWarningViolations": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "(v4 only) Suppress warning violations, such as those related to StripInaccessible READ access."
-                    },
-                    "codeAnalyzer.graphEngine.threadTimeout": {
-                        "type": "number",
-                        "default": 900000,
-                        "description": "(v4 only) After the thread timeout elapses, the path evaluation aborts. The default timeout is 900,000 milliseconds."
-                    },
-                    "codeAnalyzer.graphEngine.pathExpansionLimit": {
-                        "type": "number",
-                        "default": 0,
-                        "description": "(v4 only) An upper boundary to limit the complexity of code analyzed by Graph Engine. The default of 0 is a dynamically determined limit that's based on heap space. To learn more about heap space, see OutOfMemory errors in the Graph Engine documentation."
-                    },
-                    "codeAnalyzer.graphEngine.jvmArgs": {
-                        "type": "string",
-                        "description": "(v4 only) The Java Virtual Machine (JVM) arguments used to optimize Salesforce Graph Engine execution for your system."
-                    },
-                    "codeAnalyzer.scanner.engines": {
-                        "type": "string",
-                        "default": "pmd,retire-js,eslint-lwc",
-                        "description": "(v4 only) The engines to run. Specify multiple values as a comma-separated list. Possible values are pmd, pmd-appexchange, retire-js, eslint, eslint-lwc, and eslint-typescript."
-                    },
-                    "codeAnalyzer.normalizeSeverity.enabled": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "(v4 only) Output normalized severity (high, moderate, low) and engine-specific severity across all engines."
-                    },
-                    "codeAnalyzer.rules.category": {
-                        "type": "string",
-                        "description": "(v4 only) The categories of rules to run. Specify multiple values as a comma-separated list. Run 'sf scanner rule list -e' in the terminal for the list of categories associated with a specific engine."
-                    },
-                    "codeAnalyzer.partialGraphEngineScans.enabled": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "(v4 only) Enables partial Salesforce Graph Engine scans on only the code you've modified since the initial full scan. (Beta)"
+                        "markdownDescription": "Selection of rules used to scan your code with Code Analyzer.\n\nSelect rules using their name, engine name, severity level, tag, or a combination. Use commas for unions (such as \"Security,Performance\") and colons for intersections (such as \"pmd:Security\" or \"eslint:3\").\n\nThis setting is equivalent to the `--rule-selector` flag of the CLI commands. See [examples](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_code-analyzer_commands_unified.htm#cli_reference_code-analyzer_rules_unified)."
                     }
                 }
             }
@@ -232,14 +171,6 @@
                 {
                     "command": "sfca.runOnSelected",
                     "when": "false"
-                },
-                {
-                    "command": "sfca.runDfaOnSelectedMethod",
-                    "when": "false"
-                },
-                {
-                    "command": "sfca.runDfa",
-                    "when": "sfca.extensionActivated && sfca.partialRunsEnabled && sfca.codeAnalyzerV4Enabled"
                 },
                 {
                     "command": "sfca.removeDiagnosticsOnActiveFile",
@@ -262,10 +193,6 @@
                 {
                     "command": "sfca.runOnActiveFile",
                     "when": "sfca.extensionActivated"
-                },
-                {
-                    "command": "sfca.runDfaOnSelectedMethod",
-                    "when": "sfca.extensionActivated && sfca.codeAnalyzerV4Enabled"
                 },
                 {
                     "command": "sfca.removeDiagnosticsOnActiveFile",

--- a/src/lib/code-analyzer.ts
+++ b/src/lib/code-analyzer.ts
@@ -1,5 +1,4 @@
 import {Violation} from "./diagnostics";
-import {CliScannerV4Strategy} from "./scanner-strategies/v4-scanner";
 import {CliScannerV5Strategy} from "./scanner-strategies/v5-scanner";
 import {SettingsManager} from "./settings";
 import {Display} from "./display";
@@ -26,7 +25,6 @@ export class CodeAnalyzerImpl implements CodeAnalyzer {
 
     private cliIsInstalled: boolean = false;
 
-    private codeAnalyzerV4?: CliScannerV4Strategy;
     private codeAnalyzerV5?: CliScannerV5Strategy;
 
     constructor(cliCommandExecutor: CliCommandExecutor, settingsManager: SettingsManager, display: Display,
@@ -44,28 +42,12 @@ export class CodeAnalyzerImpl implements CodeAnalyzer {
             }
             this.cliIsInstalled = true;
         }
-        if (this.settingsManager.getCodeAnalyzerUseV4Deprecated()) {
-            await this.validateV4Plugin();
-        } else {
-            await this.validateV5Plugin();
-        }
+        await this.validateV5Plugin();
     }
 
     private async getDelegate(): Promise<CliScannerStrategy> {
         await this.validateEnvironment();
-        return this.settingsManager.getCodeAnalyzerUseV4Deprecated() ? this.codeAnalyzerV4 : this.codeAnalyzerV5;
-    }
-
-    private async validateV4Plugin(): Promise<void> {
-        if (this.codeAnalyzerV4 !== undefined) {
-            return; // Already validated
-        }
-        // Even though v4 is a JIT plugin... in the future it might not be. So we validate for future proofing.
-        const installedVersion: semver.SemVer | undefined = await this.cliCommandExecutor.getSfCliPluginVersion('@salesforce/sfdx-scanner');
-        if (!installedVersion) {
-            throw new Error(messages.error.sfdxScannerMissing);
-        }
-        this.codeAnalyzerV4 = new CliScannerV4Strategy(installedVersion, this.cliCommandExecutor, this.settingsManager, this.fileHandler);
+        return this.codeAnalyzerV5;
     }
 
     private async validateV5Plugin(): Promise<void> {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -11,8 +11,6 @@ export interface SettingsManager {
     getAnalyzeOnOpen(): boolean;
     getAnalyzeOnSave(): boolean;
     getApexGuruEnabled(): boolean;
-    getCodeAnalyzerUseV4Deprecated(): boolean;
-    setCodeAnalyzerUseV4Deprecated(value: boolean): void;
 
     // v5 Settings
     getCodeAnalyzerConfigFile(): string;
@@ -49,26 +47,8 @@ export class SettingsManagerImpl implements SettingsManager {
         return vscode.workspace.getConfiguration('codeAnalyzer.apexGuru').get('enabled');
     }
 
-    public getCodeAnalyzerUseV4Deprecated(): boolean {
-        return vscode.workspace.getConfiguration('codeAnalyzer').get('Use v4 (Deprecated)');
-    }
-
-    /**
-     * Sets the 'Use v4 (Deprecated)' value at the user (global) level and removes the setting at all other levels
-     */
-    public setCodeAnalyzerUseV4Deprecated(value: boolean): void {
-        void vscode.workspace.getConfiguration('codeAnalyzer').update('Use v4 (Deprecated)', value, vscode.ConfigurationTarget.Global);
-
-        // If there is a workspace open (which is true if workspaceFolders is nonempty), then we should update the workspace settings
-        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-            void vscode.workspace.getConfiguration('codeAnalyzer').update('Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.Workspace);
-            void vscode.workspace.getConfiguration('codeAnalyzer').update('Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-        }
-    }
-
-
     // =================================================================================================================
-    // ==== v5 Settings
+    // ==== Configuration Settings
     // =================================================================================================================
     public getCodeAnalyzerConfigFile(): string {
         return vscode.workspace.getConfiguration('codeAnalyzer').get('configFile');

--- a/src/test/legacy/extension.test.ts
+++ b/src/test/legacy/extension.test.ts
@@ -15,23 +15,19 @@ import {
     SFCAExtensionData
 } from '../../extension';
 import {messages} from '../../lib/messages';
-import {SettingsManager, SettingsManagerImpl} from '../../lib/settings';
+import {SettingsManagerImpl} from '../../lib/settings';
 import * as Constants from '../../lib/constants';
 import * as targeting from '../../lib/targeting';
 import * as vscode from 'vscode';
 import {DiagnosticManager, DiagnosticManagerImpl} from '../../lib/diagnostics';
 import {SpyLogger, StubTelemetryService} from "./test-utils";
-import {DfaRunner} from "../../lib/dfa-runner";
 import {CodeAnalyzerRunAction} from "../../lib/code-analyzer-run-action";
 import {CodeAnalyzer, CodeAnalyzerImpl} from "../../lib/code-analyzer";
 import {TaskWithProgressRunner, TaskWithProgressRunnerImpl} from "../../lib/progress";
 import {Display, VSCodeDisplay} from "../../lib/display";
-import {CliCommandExecutorImpl} from "../../lib/cli-commands";
-import {Logger} from "../../lib/logger";
 import {
     SpyWindowManager,
     StubFileHandler,
-    StubSettingsManager,
     StubSpyCliCommandExecutor,
     StubVscodeWorkspace
 } from "../unit/stubs";
@@ -82,10 +78,7 @@ suite('Extension Test Suite', () => {
                 Sinon.restore();
             });
 
-            async function runTest(desiredV5EnablementStatus: boolean): Promise<void> {
-                // ===== SETUP =====
-                // Set V5's enablement to the desired state.
-                Sinon.stub(SettingsManagerImpl.prototype, 'getCodeAnalyzerUseV4Deprecated').returns(!desiredV5EnablementStatus);
+            async function runTest(): Promise<void> {
 
                 // ===== TEST =====
                 // Run the "scan active file" command.
@@ -105,14 +98,9 @@ suite('Extension Test Suite', () => {
                 }
             }
 
-            test('Adds proper diagnostics when running with v4', async function() {
-                this.timeout(90000);
-                await runTest(false);
-            });
-
             test('Adds proper diagnostics when running with v5', async function() {
                 this.timeout(90000);
-                await runTest(true);
+                await runTest();
             });
         });
 
@@ -125,11 +113,7 @@ suite('Extension Test Suite', () => {
                     Sinon.restore();
                 });
 
-                async function runTest(desiredV5EnablementStatus: boolean): Promise<void> {
-                    // ===== SETUP =====
-                    // Set V5's enablement to the desired state.
-                    Sinon.stub(SettingsManagerImpl.prototype, 'getCodeAnalyzerUseV4Deprecated').returns(!desiredV5EnablementStatus);
-
+                async function runTest(): Promise<void> {
                     // ===== TEST =====
                     // Run the "scan selected files" command.
                     // Pass the URI in as the first parameter, since that's what happens on a single-file selection.
@@ -146,21 +130,13 @@ suite('Extension Test Suite', () => {
                     }
                 }
 
-                test('Adds proper diagnostics when running with v4', async function() {
-                    this.timeout(90000);
-                    await runTest(false);
-                });
-
                 test('Adds proper diagnostics when running with v5', async function() {
                     this.timeout(90000);
-                    await runTest(true);
+                    await runTest();
                 });
             });
 
             suite('One folder selected', () => {
-                test('Adds proper diagnostics when running with v4', async function() {
-                    // TODO: WRITE THIS TEST
-                });
 
                 test('Adds proper diagnostics when running with v5', async function() {
                     // TODO: WRITE THIS TEST
@@ -176,11 +152,7 @@ suite('Extension Test Suite', () => {
                     Sinon.restore();
                 });
 
-                async function runTest(desiredV5EnablementStatus: boolean): Promise<void> {
-                    // ===== SETUP =====
-                    // Set V5's enablement to the desired state.
-                    Sinon.stub(SettingsManagerImpl.prototype, 'getCodeAnalyzerUseV4Deprecated').returns(!desiredV5EnablementStatus);
-
+                async function runTest(): Promise<void> {
                     // ===== TEST =====
                     // Run the "scan selected files" command.
                     // Pass the URIs in as the second parameter, since that's what happens on a multi-select pick.
@@ -200,21 +172,13 @@ suite('Extension Test Suite', () => {
                     }
                 }
 
-                test('Adds proper diagnostics when running with v4', async function() {
-                    this.timeout(90000);
-                    await runTest(false);
-                });
-
                 test('Adds proper diagnostics when running with v5', async function() {
                     this.timeout(90000);
-                    await runTest(true);
+                    await runTest();
                 });
             });
         });
 
-        test('sfca.runDfaOnSelected', async () => {
-            // TODO: Add actual tests for `runDfaOnSelected`.
-        });
     });
 
     suite('#_runAndDisplay()', () => {
@@ -269,197 +233,6 @@ suite('Extension Test Suite', () => {
                 expect(sentExceptions[0].message).to.include(messages.error.sfMissing);
                 expect(sentExceptions[0].data).to.haveOwnProperty('executedCommand', fakeTelemetryName, 'Wrong command name applied');
             });
-        });
-    });
-
-    suite('#_runAndDisplayDfa()', () => {
-        let settingsManager: SettingsManager;
-
-        setup(() => {
-            settingsManager = new StubSettingsManager();
-            settingsManager.setCodeAnalyzerUseV4Deprecated(true);
-        });
-
-        teardown(() => {
-            settingsManager.setCodeAnalyzerUseV4Deprecated(false);
-        });
-
-        suite('Error handling', () => {
-            teardown(() => {
-                Sinon.restore();
-            });
-
-            test('Throws error if `sf` is missing', async function () {
-                this.timeout(90000);
-
-                // ===== SETUP =====
-                const stubTelemetryService: StubTelemetryService = new StubTelemetryService();
-                // Simulate SF being unavailable.
-                const errorSpy = Sinon.spy(vscode.window, 'showErrorMessage');
-                const cliCommandExecutor: StubSpyCliCommandExecutor = new StubSpyCliCommandExecutor();
-                cliCommandExecutor.isSfInstalledReturnValue = false;
-                const fakeTelemetryName = 'FakeName';
-
-                const context: vscode.ExtensionContext = null; // Not needed for this test, so just setting it to null
-                const logger: Logger = new SpyLogger();
-                const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(cliCommandExecutor, settingsManager, new VSCodeDisplay(logger));
-                const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, stubTelemetryService, logger)
-
-                // ===== TEST =====
-                // Attempt to run the appropriate extension command.
-                await dfaRunner._runAndDisplayDfa(fakeTelemetryName, null, ['someMethod'], 'some/project/dir');
-
-                // ===== ASSERTIONS =====
-                Sinon.assert.callCount(errorSpy, 1);
-                expect(errorSpy.firstCall.args[0]).to.include(messages.error.sfMissing);
-                const sentExceptions = stubTelemetryService.getSentExceptions();
-                expect(sentExceptions.length).to.equal(1, 'Wrong number of exceptions sent');
-                expect(sentExceptions[0].name).to.equal(Constants.TELEM_FAILED_DFA_ANALYSIS, 'Wrong telemetry key');
-                expect(sentExceptions[0].message).to.include(messages.error.sfMissing);
-                expect(sentExceptions[0].data).to.haveOwnProperty('executedCommand', fakeTelemetryName, 'Wrong command name applied');
-            });
-
-            test('Throws error if `sfdx-scanner` is missing', async function () {
-                this.timeout(90000);
-
-                // ===== SETUP =====
-                const stubTelemetryService: StubTelemetryService = new StubTelemetryService();
-                // Simulate SF being available but SFDX Scanner being absent.
-                const errorSpy = Sinon.spy(vscode.window, 'showErrorMessage');
-                const cliCommandExecutor: StubSpyCliCommandExecutor = new StubSpyCliCommandExecutor();
-                cliCommandExecutor.isSfInstalledReturnValue = true;
-                cliCommandExecutor.getSfCliPluginVersionReturnValue = null;
-                const fakeTelemetryName = 'FakeName';
-
-                const context: vscode.ExtensionContext = null; // Not needed for this test, so just setting it to null
-                const logger: Logger = new SpyLogger();
-                const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(cliCommandExecutor, settingsManager, new VSCodeDisplay(logger));
-                const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, stubTelemetryService, logger)
-
-                // ===== TEST =====
-                try {
-                    await dfaRunner._runAndDisplayDfa(fakeTelemetryName, null, ['someMethod'], 'some/project/dir');
-                } catch (_e) {
-                    // Spy will check the error
-                }
-
-                // ===== ASSERTIONS =====
-                Sinon.assert.callCount(errorSpy, 1);
-                expect(errorSpy.firstCall.args[0]).to.include(messages.error.sfdxScannerMissing);
-                const sentExceptions = stubTelemetryService.getSentExceptions();
-                expect(sentExceptions.length).to.equal(1, 'Wrong number of exceptions');
-                expect(sentExceptions[0].name).to.equal(Constants.TELEM_FAILED_DFA_ANALYSIS, 'Wrong telemetry key');
-                expect(sentExceptions[0].message).to.include(messages.error.sfdxScannerMissing);
-                expect(sentExceptions[0].data).to.haveOwnProperty('executedCommand', fakeTelemetryName, 'Wrong command name applied');
-            });
-        });
-    });
-
-    suite('#_shouldProceedWithDfaRun()', () => {
-        let settingsManager: SettingsManager;
-
-        setup(() => {
-            settingsManager = new SettingsManagerImpl();
-            settingsManager.setCodeAnalyzerUseV4Deprecated(true);
-        });
-
-        const ext: vscode.Extension<SFCAExtensionData> = vscode.extensions.getExtension('salesforce.sfdx-code-analyzer-vscode');
-        let context: vscode.ExtensionContext;
-
-        suiteSetup(async function () {
-            // Activate the extension.
-            const extData: SFCAExtensionData = await ext.activate();
-            context = extData.context;
-        });
-
-        teardown(async () => {
-            Sinon.restore();
-            await context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, undefined);
-            settingsManager.setCodeAnalyzerUseV4Deprecated(false);
-        });
-
-        test('Returns true and confirmation message not called when no existing DFA process detected', async function () {
-            this.timeout(90000);
-
-            const infoMessageSpy = Sinon.spy(vscode.window, 'showInformationMessage');
-
-            await context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, undefined);
-
-            const logger: Logger = new SpyLogger();
-            const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(new CliCommandExecutorImpl(new SpyLogger()), settingsManager, new VSCodeDisplay(logger));
-            const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, new StubTelemetryService(), logger)
-
-            expect(await dfaRunner.shouldProceedWithDfaRun()).to.equal(true);
-            Sinon.assert.callCount(infoMessageSpy, 0);
-        });
-
-        test('Confirmation message called when DFA process detected', async function () {
-            this.timeout(90000);
-
-            const infoMessageSpy = Sinon.spy(vscode.window, 'showInformationMessage');
-            await context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, 1234);
-
-            const logger: Logger = new SpyLogger();
-            const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(new CliCommandExecutorImpl(new SpyLogger()),
-                settingsManager, new VSCodeDisplay(logger));
-            const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, new StubTelemetryService(), logger)
-
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            dfaRunner.shouldProceedWithDfaRun();
-
-            Sinon.assert.callCount(infoMessageSpy, 1);
-            expect(infoMessageSpy.firstCall.args[0]).to.include(messages.graphEngine.existingDfaRunText);
-        });
-    });
-
-    suite('#_stopExistingDfaRun()', function () {
-
-        let settingsManager: SettingsManager;
-
-        setup(() => {
-            settingsManager = new SettingsManagerImpl();
-            settingsManager.setCodeAnalyzerUseV4Deprecated(true);
-        });
-
-        const ext: vscode.Extension<SFCAExtensionData> = vscode.extensions.getExtension('salesforce.sfdx-code-analyzer-vscode');
-        let context: vscode.ExtensionContext;
-
-        suiteSetup(async () => {
-            // Activate the extension.
-            const extData: SFCAExtensionData = await ext.activate();
-            context = extData.context;
-        });
-
-        teardown(() => {
-            void context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, undefined);
-            Sinon.restore();
-            settingsManager.setCodeAnalyzerUseV4Deprecated(false);
-        });
-
-        test('Cache cleared as part of stopping the existing DFA run', async function () {
-            this.timeout(90000);
-
-            context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, 1234);
-
-            const logger: Logger = new SpyLogger();
-            const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(new CliCommandExecutorImpl(logger), settingsManager, new VSCodeDisplay(logger));
-            const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, new StubTelemetryService(), logger)
-
-            await dfaRunner.stopExistingDfaRun();
-            expect(context.workspaceState.get(Constants.WORKSPACE_DFA_PROCESS)).to.be.undefined;
-        });
-
-        test('Cache stays cleared when there are no existing DFA runs', function () {
-            this.timeout(90000);
-
-            void context.workspaceState.update(Constants.WORKSPACE_DFA_PROCESS, undefined);
-            const logger: Logger = new SpyLogger();
-            const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(new CliCommandExecutorImpl(logger), settingsManager, new VSCodeDisplay(logger));
-            const dfaRunner: DfaRunner = new DfaRunner(context, codeAnalyzer, new StubTelemetryService(), logger)
-
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            dfaRunner.stopExistingDfaRun();
-            expect(context.workspaceState.get(Constants.WORKSPACE_DFA_PROCESS)).to.be.undefined;
         });
     });
 

--- a/src/test/legacy/scanner.test.ts
+++ b/src/test/legacy/scanner.test.ts
@@ -370,12 +370,6 @@ class StubSettingsManager implements SettingsManager {
         this.resetSettings();
     }
 
-    getCodeAnalyzerUseV4Deprecated(): boolean {
-        throw new Error('Method not implemented.');
-    }
-    setCodeAnalyzerUseV4Deprecated(_value: boolean): void {
-        throw new Error('Method not implemented.');
-    }
     getCodeAnalyzerConfigFile(): string | undefined {
         throw new Error('Method not implemented.');
     }

--- a/src/test/unit/lib/code-analyzer.test.ts
+++ b/src/test/unit/lib/code-analyzer.test.ts
@@ -5,7 +5,6 @@ import {messages} from "../../../lib/messages";
 import {Violation} from "../../../lib/diagnostics";
 import * as path from "path";
 import {Workspace} from "../../../lib/workspace";
-import {StubVscodeWorkspace} from "../stubs";
 
 const TEST_DATA_DIR: string = path.resolve(__dirname, '..', 'test-data');
 
@@ -276,64 +275,4 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
         });
     });
 
-    describe('When using the "Use v4 (Deprecated)" setting ...', () => {
-        beforeEach(() => {
-            settingsManager.getCodeAnalyzerUseV4DeprecatedReturnValue = true;
-        });
-
-        describe('v4 tests for the validateEnvironment method', () => {
-            it('When the Salesforce CLI is not installed, then error', async () => {
-                cliCommandExecutor.isSfInstalledReturnValue = false;
-                await expect(codeAnalyzer.validateEnvironment()).rejects.toThrow(messages.error.sfMissing);
-            });
-
-            it('When the scanner plugin is not installed, then error', async () => {
-                cliCommandExecutor.getSfCliPluginVersionReturnValue = undefined;
-                await expect(codeAnalyzer.validateEnvironment()).rejects.toThrow(messages.error.sfdxScannerMissing);
-            });
-
-            it('When the scanner plugin is installed, then no error and no warning', async () => {
-                cliCommandExecutor.getSfCliPluginVersionReturnValue = new semver.SemVer('4.9.0');
-                await codeAnalyzer.validateEnvironment();
-                expect(display.displayErrorCallHistory).toHaveLength(0);
-                expect(display.displayWarningCallHistory).toHaveLength(0);
-            });
-        });
-
-        describe('v4 tests for the getScannerName method', () => {
-            it('Sanity check that getScannerName first calls validateEnvironment', async () => {
-                cliCommandExecutor.isSfInstalledReturnValue = false;
-                await expect(codeAnalyzer.getScannerName()).rejects.toThrow(messages.error.sfMissing);
-            });
-
-            it('When he scanner name reflects the v4 version', async () => {
-                settingsManager.getCodeAnalyzerUseV4DeprecatedReturnValue = true;
-                cliCommandExecutor.getSfCliPluginVersionReturnValue = new semver.SemVer('4.5.0');
-                const scannerName: string = await codeAnalyzer.getScannerName();
-                expect(scannerName).toEqual('@salesforce/sfdx-scanner@4.5.0 via CLI');
-            });
-        });
-
-        describe('v4 tests for the scan method', () => {
-            it('Sanity check that scan first calls validateEnvironment', async () => {
-                cliCommandExecutor.isSfInstalledReturnValue = false;
-                const workspace: Workspace = await Workspace.fromTargetPaths([], new StubVscodeWorkspace(), fileHandler);
-                await expect(codeAnalyzer.scan(workspace)).rejects.toThrow(messages.error.sfMissing);
-            });
-
-            // TODO: More tests coming soon ...
-        });
-
-        describe('v4 tests for the getRuleDescriptionFor method', () => {
-            it('Sanity check that getRuleDescriptionFor first calls validateEnvironment', async () => {
-                cliCommandExecutor.isSfInstalledReturnValue = false;
-                await expect(codeAnalyzer.getRuleDescriptionFor('someEngine','someRule')).rejects.toThrow(messages.error.sfMissing);
-            });
-
-            it('When getRuleDescriptionFor is called, then it always just returns empty since this is bonus functionality for A4D', async () => {
-                const description: string = await codeAnalyzer.getRuleDescriptionFor('pmd', 'ApexDoc');
-                expect(description).toEqual('');
-            });
-        });
-    });
 });

--- a/src/test/unit/lib/settings.test.ts
+++ b/src/test/unit/lib/settings.test.ts
@@ -44,32 +44,6 @@ describe('Tests for the SettingsManagerImpl class ', () => {
             expect(getMock).toHaveBeenCalledWith('enabled');
         });
 
-        it('should get useV4Deprecated', () => {
-            getMock.mockReturnValue(false);
-            expect(settingsManager.getCodeAnalyzerUseV4Deprecated()).toBe(false);
-            expect(getMock).toHaveBeenCalledWith('Use v4 (Deprecated)');
-        });
-
-        it('should set useV4Deprecated and remove it at global level', () => {
-            settingsManager.setCodeAnalyzerUseV4Deprecated(true);
-            expect(updateMock).toHaveBeenNthCalledWith(1, 'Use v4 (Deprecated)', true, vscode.ConfigurationTarget.Global);
-            expect(updateMock).not.toHaveBeenNthCalledWith(2, 'Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.Workspace);
-            expect(updateMock).not.toHaveBeenNthCalledWith(3, 'Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-        });
-
-        it('should set useV4Deprecated and remove it at workspace levels when workspace folder exists', () => {
-            const someFolder: vscode.WorkspaceFolder = {
-                uri: vscode.Uri.file('/some/file'),
-                name: 'someName',
-                index: 0
-            };
-            jest.spyOn(vscode.workspace, 'workspaceFolders', 'get').mockReturnValue([someFolder]); // Simulate that workspace is open
-        
-            settingsManager.setCodeAnalyzerUseV4Deprecated(true);
-            expect(updateMock).toHaveBeenNthCalledWith(1, 'Use v4 (Deprecated)', true, vscode.ConfigurationTarget.Global);
-            expect(updateMock).toHaveBeenNthCalledWith(2, 'Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.Workspace);
-            expect(updateMock).toHaveBeenNthCalledWith(3, 'Use v4 (Deprecated)', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-        });
     });
 
     describe('v5 Settings', () => {

--- a/src/test/unit/stubs.ts
+++ b/src/test/unit/stubs.ts
@@ -272,16 +272,6 @@ export class StubSettingsManager implements SettingsManager {
         return this.getApexGuruEnabledReturnValue;
     }
 
-    getCodeAnalyzerUseV4DeprecatedReturnValue: boolean = false;
-
-    getCodeAnalyzerUseV4Deprecated(): boolean {
-        return this.getCodeAnalyzerUseV4DeprecatedReturnValue;
-    }
-
-    setCodeAnalyzerUseV4Deprecated(value: boolean): void {
-        this.getCodeAnalyzerUseV4DeprecatedReturnValue = value;
-    }
-
     // =================================================================================================================
     // ==== v5 Settings
     // =================================================================================================================


### PR DESCRIPTION
This PR:
- Removes the settings for using Code Analyzer v4 (Scanner): `Use v4 (Deprecated)`.
- Removes contributions associated with v4 (such as DFA commands).
- Consolidates our existing settings page.
- Defaults all users to `code-analyzer` plugin (v5).
- Cleans up necessary code for this change. Full cleanup will happen in a follow-up PR.

<img width="866" height="830" alt="Screenshot 2025-08-04 at 11 42 54 AM" src="https://github.com/user-attachments/assets/6562ba25-472d-4786-8579-a1e58ed96382" />
