### PR TITLE
CHANGE: @W-17987318@ Add automatic retries to heartbeat and smoke tests

### DIFF
--- a/.github/workflows/daily-smoke-test.yml
+++ b/.github/workflows/daily-smoke-test.yml
@@ -11,30 +11,43 @@ on:
 jobs:
   # Step 1: Build the tarballs so they can be installed locally.
   build-code-analyzer-tarball:
-    name: 'Build code analyzer tarball'
+    name: Build code analyzer tarball
     uses: ./.github/workflows/build-tarball.yml
     with:
       target-branch: 'dev'
   # Step 2: Actually run the tests.
   smoke-test:
-    name: 'Run smoke tests'
+    name: Run smoke tests
     needs: [build-code-analyzer-tarball]
     uses: ./.github/workflows/run-tests.yml
     with:
       use-tarballs: true
       tarball-suffix: 'dev'
     secrets: inherit
-  # Step 3: Build a VSIX artifact for use if needed.
+  # Step 3: Retry on failure after install timeout or flaky tests
+  retry-on-failure:
+    name: Retry on failure
+    runs-on: ubuntu-latest
+    needs: [build-code-analyzer-tarball, smoke-test]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    steps:
+      - name: Trigger retry workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run retry.yml -F github_run_id=${{ github.run_id }}
+  # Step 4: Build a VSIX artifact for use if needed.
   create-vsix-artifact:
     name: 'Upload VSIX as artifact'
     uses: ./.github/workflows/create-vsix-artifact.yml
     secrets: inherit
-  # Step 4: Report any problems
+  # Step 5: Report any problems
   report-problems:
-    name: 'Report problems'
+    name: Report problems
     runs-on: ubuntu-latest
     needs: [build-code-analyzer-tarball, smoke-test, create-vsix-artifact]
-    if: ${{ failure() || cancelled() }}
+    if: failure() && fromJSON(github.run_attempt) >= 3
     steps:
       - name: Report problems
         shell: bash
@@ -42,7 +55,7 @@ jobs:
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           ALERT_SEV="info"
-          ALERT_SUMMARY="Daily smoke test failed on ${{ runner.os }}"
+          ALERT_SUMMARY="Daily smoke test failed after 3 attempts on ${{ runner.os }}"
 
           generate_post_data() {
             cat <<EOF

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -91,7 +91,7 @@ jobs:
           fi
         shell: bash
 
-      # 3 Install VS Code and Extension on macOS
+      # 3 Install and Verify VS Code and Extension on macOS
       - name: Install VS Code on macOS
         if: runner.os == 'macOS'
         run: |
@@ -111,21 +111,35 @@ jobs:
             echo "::error Extension installation failed" && exit 1
           fi
 
-      # === Report any problems ===
+  # Retry on failure after matrix is complete
+  retry-on-failure:
+    name: Retry on failure
+    runs-on: ubuntu-latest
+    needs: [production-heartbeat]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    steps:
+      - name: Trigger retry workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run retry.yml -F github_run_id=${{ github.run_id }}
+
+  # Report problems after retry mechanism is complete
+  report-problems:
+    name: Report problems
+    runs-on: ubuntu-latest
+    needs: [production-heartbeat, retry-on-failure]
+    if: failure() && fromJSON(github.run_attempt) >= 3
+    steps:
       - name: Report problems
-        # There are problems if any step failed or was skipped.
-        # Note that the `join()` call omits null values, so if any steps were skipped, they won't have a corresponding
-        # value in the string.
-        if: ${{ failure() || cancelled() }}
         shell: bash
         env:
           # A link to this run, so the PagerDuty assignee can quickly get here.
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
         run: |
-
           ALERT_SEV="info"
-          ALERT_SUMMARY="Production heartbeat script failed on ${{ runner.os }}"
+          ALERT_SUMMARY="Production heartbeat script failed after 3 attempts on ${{ runner.os }}"
           # Define a helper function to create our POST request's data, to sidestep issues with nested quotations.
           generate_post_data() {
           # This is known as a HereDoc, and it lets us declare multi-line input ending when the specified limit string,

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,0 +1,20 @@
+# This workflow is used in order to retry a failed workflow run.
+name: Retry workflow
+on:
+  workflow_dispatch:
+    inputs:
+      github_run_id:
+        required: true
+        description: "The ID of the workflow run to retry"
+jobs:
+  Retry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry Github Action ${{ inputs.github_run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api # Used for verbose output
+        run: |
+          gh run watch ${{ inputs.github_run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.github_run_id }} --failed


### PR DESCRIPTION
This PR:
- Adds retry mechanisms to both the Production Heartbeat and the Daily Smoke Tests github actions such that if the workflow fails they are each retried twice for a total of 3 runs before alerting the channel to failures.