### PR TITLE
CHANGE: @W-19345132@ Refactor ApexGuruAccess and ApexGuruAvailability to ApexGuruOrgStatus

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import {PMDSupressionsCodeActionProvider} from './lib/pmd/pmd-suppressions-code-
 import {ApplyViolationFixesActionProvider} from './lib/apply-violation-fixes-action-provider';
 import {ApplyViolationFixesAction} from './lib/apply-violation-fixes-action';
 import {ViolationSuggestionsHoverProvider} from './lib/violation-suggestions-hover-provider';
-import {ApexGuruAccess, ApexGuruAvailability, ApexGuruService, LiveApexGuruService} from './lib/apexguru/apex-guru-service';
+import {ApexGuruOrgStatus, ApexGuruService, LiveApexGuruService} from './lib/apexguru/apex-guru-service';
 import {ApexGuruRunAction} from './lib/apexguru/apex-guru-run-action';
 import {OrgConnectionService} from './lib/external-services/org-connection-service';
 
@@ -248,16 +248,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
     const apexGuruRunAction: ApexGuruRunAction = new ApexGuruRunAction(taskWithProgressRunner, apexGuruService, diagnosticManager, telemetryService, display);
 
     // TODO: This is temporary and will change soon when we remove pilot flag and instead add a watch to org auth changes
-    const isApexGuruEnabled: () => Promise<boolean> = async () => {
+    const isApexGuruFeatureEnabled: () => Promise<boolean> = async () => {
         if (!settingsManager.getApexGuruEnabled()) {
             return false;
         }
-        const availability: ApexGuruAvailability = await apexGuruService.getAvailability();
-        if (availability.access === ApexGuruAccess.ENABLED || availability.access === ApexGuruAccess.ELIGIBLE) {
+        const apexGuruOrgStatus: ApexGuruOrgStatus = await apexGuruService.getApexGuruOrgStatus();
+        if (apexGuruOrgStatus.enabled || apexGuruOrgStatus.eligible) {
             return true;
         }
     };
-    await establishVariableInContext(Constants.CONTEXT_VAR_APEX_GURU_ENABLED, isApexGuruEnabled);
+    await establishVariableInContext(Constants.CONTEXT_VAR_APEX_GURU_ENABLED, isApexGuruFeatureEnabled);
 
     // COMMAND_RUN_APEX_GURU_ON_FILE: Invokable by 'explorer/context' menu only when: "sfca.apexGuruEnabled && explorerResourceIsFolder == false && resourceExtname =~ /\\.cls|\\.trigger|\\.apex/"
     registerCommand(Constants.COMMAND_RUN_APEX_GURU_ON_FILE, async (selection: vscode.Uri, multiSelect?: vscode.Uri[]) => {

--- a/src/test/unit/lib/apexguru/apex-guru-run-action.test.ts
+++ b/src/test/unit/lib/apexguru/apex-guru-run-action.test.ts
@@ -5,7 +5,6 @@ import { CodeAnalyzerDiagnostic, DiagnosticManager, DiagnosticManagerImpl, Viola
 import { FakeDiagnosticCollection } from "../../vscode-stubs";
 import { ApexGuruRunAction } from "../../../../lib/apexguru/apex-guru-run-action";
 import { createSampleCodeAnalyzerDiagnostic } from "../../test-utils";
-import { ApexGuruAccess } from "../../../../lib/apexguru/apex-guru-service";
 
 describe("Tests for ApexGuruRunAction", () => {
     const sampleUri: vscode.Uri = vscode.Uri.file('/some/file.cls');
@@ -61,8 +60,9 @@ describe("Tests for ApexGuruRunAction", () => {
     });
 
     it("When user's org is eligible but not enabled, then ApexGuru scan button results in an error window with instructions", async () => {
-        apexGuruService.getAvailabilityReturnValue = {
-            access: ApexGuruAccess.ELIGIBLE,
+        apexGuruService.orgStatusReturnValue = {
+            enabled: false,
+            eligible: true,
             message: "Some instructions from ApexGuru"
         };
 
@@ -79,8 +79,8 @@ describe("Tests for ApexGuruRunAction", () => {
         expect(telemetryService.sendCommandEventCallHistory).toHaveLength(1);
         expect(telemetryService.sendCommandEventCallHistory[0].commandName).toEqual('sfdx__apexguru_file_run_not_enabled');
         expect(telemetryService.sendCommandEventCallHistory[0].properties).toEqual({
-            access: 'eligible-but-not-enabled',
-            executedCommand: 'SomeCommandName'
+            executedCommand: 'SomeCommandName',
+            message: 'Some instructions from ApexGuru'
         });
 
         // Also validate that we didn't modify the existing diagnostics at all

--- a/src/test/unit/stubs.ts
+++ b/src/test/unit/stubs.ts
@@ -15,7 +15,7 @@ import * as semver from "semver";
 import {FileHandler} from "../../lib/fs-utils";
 import {VscodeWorkspace, WindowManager} from "../../lib/vscode-api";
 import {Workspace} from "../../lib/workspace";
-import { ApexGuruAccess, ApexGuruAvailability, ApexGuruService } from "../../lib/apexguru/apex-guru-service";
+import {ApexGuruOrgStatus, ApexGuruService } from "../../lib/apexguru/apex-guru-service";
 
 
 export class SpyTelemetryService implements TelemetryService {
@@ -364,12 +364,13 @@ export class SpyWindowManager implements WindowManager {
 }
 
 export class StubApexGuruService implements ApexGuruService {
-    getAvailabilityReturnValue: ApexGuruAvailability = {
-        access: ApexGuruAccess.ENABLED,
+    orgStatusReturnValue: ApexGuruOrgStatus = {
+        enabled: true,
+        eligible: true,
         message: "ApexGuru access is enabled."
     };
-    getAvailability(): Promise<ApexGuruAvailability> {
-        return Promise.resolve(this.getAvailabilityReturnValue);
+    getApexGuruOrgStatus(): Promise<ApexGuruOrgStatus> {
+        return Promise.resolve(this.orgStatusReturnValue);
     }
 
     scanReturnValue: Violation[] = [];


### PR DESCRIPTION
This PR:
- Separates the concerns of `ApexGuruAccess` from a singular enum into separate boolean checks for `enabled` and `eligible` for readability.
- Renames `ApexGuruAvailability` to `ApexGuruOrgStatus` to convey that we're checking the status on the org rather than monitoring the availability of an endpoint.