### PR TITLE
FIX: @W-19461506@: Validate auth based on alias or username in addition to org

### DIFF
--- a/src/lib/external-services/org-connection-service.ts
+++ b/src/lib/external-services/org-connection-service.ts
@@ -38,7 +38,7 @@ export class LiveOrgConnectionService implements OrgConnectionService {
     }
 
     isAuthed(): boolean {
-        return this.workpaceContext.orgId?.length > 0;
+        return this.workpaceContext.orgId?.length > 0 && (this.workpaceContext.alias?.length > 0 || this.workpaceContext.username?.length > 0);
     }
 
     async getApiVersion(): Promise<string> {


### PR DESCRIPTION
This PR fixes an issue that logging out does not remove the ApexGuru buttons. This was because the auth check still sees an org id even though the user is no longer logged in. So now we make the auth check confirm the username or alias in addition to the org id to ensure that auth is valid.