### PR TITLE
CHANGE @W-21741623@ fix -language definition for Apex should be handled by the Apex extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
             },
             "engines": {
                 "node": ">=20.9.0",
-                "vscode": "^1.109.0"
+                "vscode": "^1.110.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -277,21 +277,6 @@
                     "when": "sfca.extensionActivated && sfca.shouldShowApexGuruButtons && explorerResourceIsFolder == false && resourceExtname =~ /\\.cls|\\.trigger|\\.apex/"
                 }
             ]
-        },
-        "languages": [
-            {
-                "id": "apex",
-                "aliases": [
-                    "Apex",
-                    "apex"
-                ],
-                "extensions": [
-                    ".cls",
-                    ".trigger",
-                    ".soql",
-                    ".apex"
-                ]
-            }
-        ]
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?
I removed the block of code in **package.json** that defines which type of files are language Apex.  That is already handled by the Apex extension, and should not be duplicated here.  This block of code was causing `.soql` files to be treated as language Apex instead of language SOQL as expected.

### What issues does this PR fix or reference?
[skip-validate-pr]