### PR TITLE
NEW @W-22270197@ Fix production-heartbeat GPG key verification on Ubuntu

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -25,9 +25,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt install wget gpg -y
-          wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
-          sudo install -o root -g root -m 644 packages.microsoft.gpg /usr/share/keyrings/
-          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
+          wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/packages.microsoft.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/vscode stable main" | sudo tee /etc/apt/sources.list.d/vscode.list
           sudo apt update
           sudo apt install code -y
 


### PR DESCRIPTION
## Summary

- The `production-heartbeat` workflow is failing on Ubuntu since the runner image was updated to `ubuntu24/20260513.135` (May 13, 2026)
- The new image no longer has the Microsoft GPG key in the global apt trust store (`/etc/apt/trusted.gpg.d/`)
- Our VS Code repo config was missing the `signed-by` directive, so apt couldn't verify the repo
- This fix uses the modern `signed-by` approach to explicitly tell apt which key to use for the VS Code repository

**Failing run:** https://github.com/forcedotcom/sfdx-code-analyzer-vscode/actions/runs/25916935707/job/76454079356

## Test plan

- [ ] Merge to `dev` and verify the next scheduled `production-heartbeat` run passes on Ubuntu
- [ ] Optionally trigger a manual `workflow_dispatch` run to validate immediately