### PR TITLE
CHANGE @W-22462041@ Update VS Code extension dependencies (minor/patch versions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,14 @@
                 "@types/tmp": "^0.2.6",
                 "diff": "^8.0.3",
                 "glob": "^13.0.6",
-                "semver": "^7.8.1",
-                "tmp": "^0.2.5"
+                "semver": "^7.8.4",
+                "tmp": "^0.2.7"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.2",
                 "@types/node": "^20.0.0",
                 "@types/vscode": "^1.120.0",
-                "@vscode/vsce": "^3.9.1",
+                "@vscode/vsce": "^3.9.2",
                 "esbuild": "^0.27.4",
                 "eslint": "^9.39.2",
                 "husky": "^9.1.7",
@@ -35,7 +35,7 @@
                 "ts-jest": "^29.4.11",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.59.4"
+                "typescript-eslint": "^8.61.1"
             },
             "engines": {
                 "node": ">=20.9.0",
@@ -3004,17 +3004,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
-            "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+            "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/type-utils": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/type-utils": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3027,7 +3027,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.4",
+                "@typescript-eslint/parser": "^8.62.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -3043,16 +3043,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
-            "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3068,14 +3068,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
-            "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.4",
-                "@typescript-eslint/types": "^8.59.4",
+                "@typescript-eslint/tsconfig-utils": "^8.62.0",
+                "@typescript-eslint/types": "^8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3090,14 +3090,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
-            "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4"
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3108,9 +3108,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
-            "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3125,15 +3125,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
-            "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+            "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -3150,9 +3150,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
-            "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3164,16 +3164,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
-            "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.4",
-                "@typescript-eslint/tsconfig-utils": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/project-service": "8.62.0",
+                "@typescript-eslint/tsconfig-utils": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3231,16 +3231,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
-            "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4"
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3255,13 +3255,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
-            "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/types": "8.62.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3621,9 +3621,9 @@
             ]
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
-            "integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3639,13 +3639,13 @@
                 "cockatiel": "^3.1.2",
                 "commander": "^12.1.0",
                 "form-data": "^4.0.0",
-                "glob": "^11.0.0",
+                "glob": "^13.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
                 "markdown-it": "^14.1.0",
                 "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
+                "minimatch": "^10.2.2",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "secretlint": "^10.1.2",
@@ -3812,16 +3812,6 @@
                 "win32"
             ]
         },
-        "node_modules/@vscode/vsce/node_modules/@isaacs/cliui": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@vscode/vsce/node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3845,32 +3835,7 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
@@ -3881,22 +3846,6 @@
             },
             "engines": {
                 "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/jackspeak": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^9.0.0"
-            },
-            "engines": {
-                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -9130,9 +9079,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -9850,9 +9799,9 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9867,9 +9816,9 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.14"
@@ -10122,16 +10071,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
-            "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+            "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.4",
-                "@typescript-eslint/parser": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4"
+                "@typescript-eslint/eslint-plugin": "8.62.0",
+                "@typescript-eslint/parser": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
         "@types/tmp": "^0.2.6",
         "diff": "^8.0.3",
         "glob": "^13.0.6",
-        "semver": "^7.8.1",
-        "tmp": "^0.2.5"
+        "semver": "^7.8.4",
+        "tmp": "^0.2.7"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.120.0",
-        "@vscode/vsce": "^3.9.1",
+        "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.27.4",
         "eslint": "^9.39.2",
         "husky": "^9.1.7",
@@ -59,7 +59,7 @@
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.59.4"
+        "typescript-eslint": "^8.61.1"
     },
     "extensionDependencies": [
         "salesforce.salesforcedx-vscode-core"


### PR DESCRIPTION
## Summary
Updates VS Code extension dependencies to their latest minor/patch versions for the monthly release.

## Dependency Updates
- semver: 7.8.1 → 7.8.4
- tmp: 0.2.5 → 0.2.7
- @vscode/vsce: 3.9.1 → 3.9.2
- typescript-eslint: 8.59.4 → 8.61.1

## Skipped (Major Version Updates)
- @eslint/js, eslint (v9 → v10)
- @types/node (keep v20)
- typescript (v5 → v6)
- diff (v8 → v9)
- esbuild (v0.27 → v0.28)
- ovsx (v0.10 → v1.0)
- @vscode/test-electron e2e (v2 → v3)

## Test Results
- ✅ Build successful
- ✅ All 333 unit tests passing
- ✅ Lint passing
- ✅ Extension packaging verified (`npx vsce package`)