### PR TITLE
NEW @W-22393677@ - User Not Logged In — Skip ApexGuru, Show Non-Blocking Connect Org Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "color": "#ECECEC",
         "theme": "light"
     },
-    "version": "1.20.0",
+    "version": "1.21.0-SNAPSHOT",
     "publisher": "salesforce",
     "license": "BSD-3-Clause",
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {ExternalServiceProvider} from "./lib/external-services/external-service-
 import {Logger, LoggerImpl} from "./lib/logger";
 import {TelemetryService} from "./lib/external-services/telemetry-service";
 import {CodeAnalyzerRunAction} from "./lib/code-analyzer-run-action";
+import {InsightsHandler} from "./lib/insights-handler";
 import {A4DFixActionProvider} from "./lib/agentforce/a4d-fix-action-provider";
 import {ScanManager} from './lib/scan-manager';
 import {A4DFixAction} from './lib/agentforce/a4d-fix-action';
@@ -113,7 +114,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
     const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(cliCommandExecutor, settingsManager, display, fileHandler);
 
     const diagnosticFactory = (diagnosticManager as DiagnosticManagerImpl).diagnosticFactory;
-    const codeAnalyzerRunAction: CodeAnalyzerRunAction = new CodeAnalyzerRunAction(taskWithProgressRunner, codeAnalyzer, diagnosticManager, diagnosticFactory, telemetryService, logger, display, windowManager);
+    const insightsHandler: InsightsHandler = new InsightsHandler(display, logger, externalServiceProvider, windowManager);
+    const codeAnalyzerRunAction: CodeAnalyzerRunAction = new CodeAnalyzerRunAction(taskWithProgressRunner, codeAnalyzer, diagnosticManager, diagnosticFactory, telemetryService, logger, display, windowManager, insightsHandler);
 
     // For performance reasons, it's best to kick this off in the background instead of await the promise.
     void performValidationAndCaching(codeAnalyzer, display);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<SFCAEx
     const codeAnalyzer: CodeAnalyzer = new CodeAnalyzerImpl(cliCommandExecutor, settingsManager, display, fileHandler);
 
     const diagnosticFactory = (diagnosticManager as DiagnosticManagerImpl).diagnosticFactory;
-    const insightsHandler: InsightsHandler = new InsightsHandler(display, logger, externalServiceProvider, windowManager);
+    const insightsHandler: InsightsHandler = new InsightsHandler(display, logger, externalServiceProvider, windowManager, cliCommandExecutor);
     const codeAnalyzerRunAction: CodeAnalyzerRunAction = new CodeAnalyzerRunAction(taskWithProgressRunner, codeAnalyzer, diagnosticManager, diagnosticFactory, telemetryService, logger, display, windowManager, insightsHandler);
 
     // For performance reasons, it's best to kick this off in the background instead of await the promise.

--- a/src/lib/code-analyzer-run-action.ts
+++ b/src/lib/code-analyzer-run-action.ts
@@ -4,8 +4,9 @@ import {CodeAnalyzerDiagnostic, DiagnosticFactory, DiagnosticManager, normalizeV
 import {messages} from "./messages";
 import {TelemetryService} from "./external-services/telemetry-service";
 import * as Constants from './constants';
-import {CodeAnalyzer} from "./code-analyzer";
+import {CodeAnalyzer, ScanResults} from "./code-analyzer";
 import {Display} from "./display";
+import {InsightsHandler} from "./insights-handler";
 import {getErrorMessage, getErrorMessageWithStack} from "./utils";
 import {ProgressReporter, TaskWithProgressRunner} from "./progress";
 import {WindowManager} from "./vscode-api";
@@ -23,9 +24,10 @@ export class CodeAnalyzerRunAction {
     private readonly logger: Logger;
     private readonly display: Display;
     private readonly windowManager: WindowManager;
+    private readonly insightsHandler: InsightsHandler;
     private suppressedErrors: Set<string> = new Set();
 
-    constructor(taskWithProgressRunner: TaskWithProgressRunner, codeAnalyzer: CodeAnalyzer, diagnosticManager: DiagnosticManager, diagnosticFactory: DiagnosticFactory, telemetryService: TelemetryService, logger: Logger, display: Display, windowManager: WindowManager) {
+    constructor(taskWithProgressRunner: TaskWithProgressRunner, codeAnalyzer: CodeAnalyzer, diagnosticManager: DiagnosticManager, diagnosticFactory: DiagnosticFactory, telemetryService: TelemetryService, logger: Logger, display: Display, windowManager: WindowManager, insightsHandler: InsightsHandler) {
         this.taskWithProgressRunner = taskWithProgressRunner;
         this.codeAnalyzer = codeAnalyzer;
         this.diagnosticManager = diagnosticManager;
@@ -34,6 +36,7 @@ export class CodeAnalyzerRunAction {
         this.logger = logger;
         this.display = display;
         this.windowManager = windowManager;
+        this.insightsHandler = insightsHandler;
     }
 
     /**
@@ -64,7 +67,8 @@ export class CodeAnalyzerRunAction {
                     increment: 20
                 });
                 this.logger.log(messages.info.scanningWith(await this.codeAnalyzer.getVersion()));
-                const violations: Violation[] = await this.codeAnalyzer.scan(workspace);
+                const scanResults: ScanResults = await this.codeAnalyzer.scan(workspace);
+                const violations: Violation[] = scanResults.violations;
 
                 progressReporter.reportProgress({
                     message: messages.scanProgressReport.processingResults,
@@ -107,6 +111,8 @@ export class CodeAnalyzerRunAction {
 
                 this.diagnosticManager.addDiagnostics(diagnostics);
                 void this.displayResults(targetedFiles.length, violationsWithFileLocation);
+
+                this.insightsHandler.handleInsights(scanResults.insights, () => { void this.run(commandName, workspace, trigger); });
 
                 this.telemetryService.sendCommandEvent(Constants.TELEM_SUCCESSFUL_STATIC_ANALYSIS, {
                     commandName: commandName,

--- a/src/lib/code-analyzer-run-action.ts
+++ b/src/lib/code-analyzer-run-action.ts
@@ -110,7 +110,7 @@ export class CodeAnalyzerRunAction {
                 }
 
                 this.diagnosticManager.addDiagnostics(diagnostics);
-                void this.displayResults(targetedFiles.length, violationsWithFileLocation);
+                void this.displayResults(targetedFiles.length, violationsWithFileLocation, scanResults.insights?.apexguru?.analysisMode);
 
                 this.insightsHandler.handleInsights(scanResults.insights, () => { void this.run(commandName, workspace, trigger); });
 
@@ -146,12 +146,12 @@ export class CodeAnalyzerRunAction {
         }
     }
 
-    private displayResults(numFilesScanned: number, violations: Violation[]): void {
+    private displayResults(numFilesScanned: number, violations: Violation[], apexGuruAnalysisMode?: string): void {
         const filesWithViolations: Set<string> = new Set();
         for (const violation of violations) {
             filesWithViolations.add(violation.locations[violation.primaryLocationIndex].file);
         }
-        this.display.displayInfo(messages.info.finishedScan(numFilesScanned, filesWithViolations.size, violations.length));
+        this.display.displayInfo(messages.info.finishedScan(numFilesScanned, filesWithViolations.size, violations.length, apexGuruAnalysisMode));
     }
 
     /**

--- a/src/lib/code-analyzer.ts
+++ b/src/lib/code-analyzer.ts
@@ -23,6 +23,7 @@ type ResultsJson = {
 
 export type EngineInsight = {
     status: 'completed' | 'skipped';
+    analysisMode?: string;
     error?: {
         code: string;
         message: string;

--- a/src/lib/code-analyzer.ts
+++ b/src/lib/code-analyzer.ts
@@ -18,6 +18,21 @@ import * as path from 'node:path';
 type ResultsJson = {
     runDir: string;
     violations: Violation[];
+    insights?: Record<string, EngineInsight>;
+};
+
+export type EngineInsight = {
+    status: 'completed' | 'skipped';
+    error?: {
+        code: string;
+        message: string;
+        remediation: string;
+    };
+};
+
+export type ScanResults = {
+    violations: Violation[];
+    insights?: Record<string, EngineInsight>;
 };
 
 type RulesJson = {
@@ -35,7 +50,7 @@ type RuleDescription = {
 
 export interface CodeAnalyzer {
     validateEnvironment(): Promise<void>;
-    scan(workspace: Workspace): Promise<Violation[]>;
+    scan(workspace: Workspace): Promise<ScanResults>;
     getVersion(): Promise<string>;
     getRuleDescriptionFor(engineName: string, ruleName: string): Promise<string>;
 }
@@ -116,7 +131,7 @@ export class CodeAnalyzerImpl implements CodeAnalyzer {
         return this.ruleDescriptionMap;
     }
 
-    public async scan(workspace: Workspace): Promise<Violation[]> {
+    public async scan(workspace: Workspace): Promise<ScanResults> {
         await this.validateEnvironment();
 
         const ruleSelector: string = this.settingsManager.getCodeAnalyzerRuleSelectors();
@@ -159,7 +174,10 @@ export class CodeAnalyzerImpl implements CodeAnalyzer {
 
         const resultsJsonStr: string = await fs.promises.readFile(outputFile, 'utf-8');
         const resultsJson: ResultsJson = JSON.parse(resultsJsonStr) as ResultsJson;
-        return this.processResults(resultsJson);
+        return {
+            violations: this.processResults(resultsJson),
+            insights: resultsJson.insights
+        };
     }
 
     private processResults(resultsJson: ResultsJson): Violation[] {

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -7,7 +7,7 @@ export type DisplayButton = {
 }
 
 export interface Display {
-    displayInfo(infoMsg: string): void;
+    displayInfo(infoMsg: string, ...buttons: DisplayButton[]): void;
     displayWarning(warnMsg: string, ...buttons: DisplayButton[]): void;
     displayError(errorMsg: string, ...buttons: DisplayButton[]): void;
 }
@@ -19,9 +19,17 @@ export class VSCodeDisplay implements Display {
         this.logger = logger;
     }
 
-    displayInfo(infoMsg: string): void {
-        // Not waiting for promise because we didn't add buttons and don't care if user ignores the message.
-        void vscode.window.showInformationMessage(infoMsg);
+    displayInfo(infoMsg: string, ...buttons: DisplayButton[]): void {
+        if (buttons.length > 0) {
+            void vscode.window.showInformationMessage(infoMsg, ...buttons.map(b => b.text)).then(selectedText => {
+                const selectedButton: DisplayButton = buttons.find(b => b.text === selectedText);
+                if (selectedButton) {
+                    selectedButton.callback();
+                }
+            });
+        } else {
+            void vscode.window.showInformationMessage(infoMsg);
+        }
         this.logger.log(infoMsg);
     }
 

--- a/src/lib/insights-handler.ts
+++ b/src/lib/insights-handler.ts
@@ -1,0 +1,122 @@
+import * as vscode from "vscode";
+import {EngineInsight} from "./code-analyzer";
+import {Display, DisplayButton} from "./display";
+import {Logger} from "./logger";
+import {messages} from "./messages";
+import {ExternalServiceProvider} from "./external-services/external-service-provider";
+import {WindowManager} from "./vscode-api";
+
+const ISSUES_URL = 'https://github.com/forcedotcom/sfdx-code-analyzer-vscode/issues/new';
+
+export class InsightsHandler {
+    private readonly display: Display;
+    private readonly logger: Logger;
+    private readonly externalServiceProvider: ExternalServiceProvider;
+    private readonly windowManager: WindowManager;
+    private readonly suppressedErrorCodes: Set<string> = new Set();
+
+    constructor(display: Display, logger: Logger, externalServiceProvider: ExternalServiceProvider, windowManager: WindowManager) {
+        this.display = display;
+        this.logger = logger;
+        this.externalServiceProvider = externalServiceProvider;
+        this.windowManager = windowManager;
+    }
+
+    handleInsights(insights: Record<string, EngineInsight> | undefined, retriggerScan: () => void): void {
+        if (!insights || !insights.apexguru) {
+            return;
+        }
+
+        const apexguruInsight = insights.apexguru;
+        if (apexguruInsight.status !== 'skipped') {
+            return;
+        }
+
+        const error = apexguruInsight.error;
+        if (!error) {
+            return;
+        }
+
+        if (this.suppressedErrorCodes.has(error.code)) {
+            return;
+        }
+
+        this.suppressedErrorCodes.add(error.code);
+
+        switch (error.code) {
+            case 'NO_ORG_CONNECTION':
+                this.handleNoOrgConnection(error.message, error.remediation);
+                break;
+            case 'API_UNAVAILABLE':
+                this.handleApiUnavailable(error.message, error.remediation, retriggerScan);
+                break;
+            case 'UNEXPECTED_ERROR':
+                this.handleUnexpectedError(error.message, error.remediation);
+                break;
+            default:
+                this.logger.warn(`Unknown insight error code: ${error.code}`);
+        }
+    }
+
+    private handleNoOrgConnection(message: string, remediation: string): void {
+        const connectOrgButton: DisplayButton = {
+            text: messages.insights.buttons.connectOrg,
+            callback: () => this.triggerConnectOrg(remediation)
+        };
+
+        this.display.displayInfo(
+            messages.insights.apexGuruSkipped.noOrgConnection(remediation),
+            connectOrgButton
+        );
+        this.logger.log(message);
+    }
+
+    private handleApiUnavailable(message: string, remediation: string, retriggerScan: () => void): void {
+        const retryScanButton: DisplayButton = {
+            text: messages.insights.buttons.retryScan,
+            callback: retriggerScan
+        };
+        const detailsButton: DisplayButton = {
+            text: messages.insights.buttons.details,
+            callback: () => {
+                this.logger.log(remediation);
+                this.windowManager.showLogOutputWindow();
+            }
+        };
+
+        this.display.displayInfo(
+            messages.insights.apexGuruSkipped.apiUnavailable(message),
+            retryScanButton,
+            detailsButton
+        );
+        this.logger.log(message);
+    }
+
+    private handleUnexpectedError(message: string, _remediation: string): void {
+        const viewDetailsButton: DisplayButton = {
+            text: messages.insights.buttons.viewDetails,
+            callback: () => this.windowManager.showLogOutputWindow()
+        };
+        const reportIssueButton: DisplayButton = {
+            text: messages.insights.buttons.reportIssue,
+            callback: () => this.windowManager.showExternalUrl(ISSUES_URL)
+        };
+
+        this.display.displayInfo(
+            messages.insights.apexGuruSkipped.unexpectedError(message),
+            viewDetailsButton,
+            reportIssueButton
+        );
+        this.logger.log(message);
+    }
+
+    private triggerConnectOrg(remediation: string): void {
+        void this.externalServiceProvider.isOrgConnectionServiceAvailable().then(available => {
+            if (available) {
+                void vscode.commands.executeCommand('sfdx.authorize.org');
+            } else {
+                this.display.displayInfo(messages.insights.fallback.connectOrgManual(remediation));
+            }
+        });
+    }
+}

--- a/src/lib/insights-handler.ts
+++ b/src/lib/insights-handler.ts
@@ -5,21 +5,31 @@ import {Logger} from "./logger";
 import {messages} from "./messages";
 import {ExternalServiceProvider} from "./external-services/external-service-provider";
 import {WindowManager} from "./vscode-api";
+import {CliCommandExecutor, CommandOutput} from "./cli-commands";
 
 const ISSUES_URL = 'https://github.com/forcedotcom/sfdx-code-analyzer-vscode/issues/new';
+
+type OrgInfo = {
+    alias?: string;
+    username?: string;
+    isDefaultDevHubUsername?: boolean;
+    defaultMarker?: string;
+};
 
 export class InsightsHandler {
     private readonly display: Display;
     private readonly logger: Logger;
     private readonly externalServiceProvider: ExternalServiceProvider;
     private readonly windowManager: WindowManager;
-    private readonly suppressedErrorCodes: Set<string> = new Set();
+    private readonly cliCommandExecutor: CliCommandExecutor;
+    private noOrgConnectionShown: boolean = false;
 
-    constructor(display: Display, logger: Logger, externalServiceProvider: ExternalServiceProvider, windowManager: WindowManager) {
+    constructor(display: Display, logger: Logger, externalServiceProvider: ExternalServiceProvider, windowManager: WindowManager, cliCommandExecutor: CliCommandExecutor) {
         this.display = display;
         this.logger = logger;
         this.externalServiceProvider = externalServiceProvider;
         this.windowManager = windowManager;
+        this.cliCommandExecutor = cliCommandExecutor;
     }
 
     handleInsights(insights: Record<string, EngineInsight> | undefined, retriggerScan: () => void): void {
@@ -37,20 +47,20 @@ export class InsightsHandler {
             return;
         }
 
-        if (this.suppressedErrorCodes.has(error.code)) {
-            return;
-        }
-
-        this.suppressedErrorCodes.add(error.code);
-
         switch (error.code) {
             case 'NO_ORG_CONNECTION':
-                this.handleNoOrgConnection(error.message, error.remediation);
+                // Only show once per session (non-intrusive)
+                if (!this.noOrgConnectionShown) {
+                    this.noOrgConnectionShown = true;
+                    this.handleNoOrgConnection(error.message, error.remediation);
+                }
                 break;
             case 'API_UNAVAILABLE':
+                // Always show (transient error, might work on retry)
                 this.handleApiUnavailable(error.message, error.remediation, retriggerScan);
                 break;
             case 'UNEXPECTED_ERROR':
+                // Always show (could be different errors)
                 this.handleUnexpectedError(error.message, error.remediation);
                 break;
             default:
@@ -110,13 +120,78 @@ export class InsightsHandler {
         this.logger.log(message);
     }
 
-    private triggerConnectOrg(remediation: string): void {
-        void this.externalServiceProvider.isOrgConnectionServiceAvailable().then(available => {
-            if (available) {
-                void vscode.commands.executeCommand('sfdx.authorize.org');
-            } else {
-                this.display.displayInfo(messages.insights.fallback.connectOrgManual(remediation));
-            }
+    private triggerConnectOrg(_remediation: string): void {
+        this.showOrgQuickPickOrLogin().catch(err => {
+            this.logger.error(`Connect Org failed: ${err}`);
         });
+    }
+
+    private async showOrgQuickPickOrLogin(): Promise<void> {
+        const orgs = await this.listAuthenticatedOrgs();
+
+        if (orgs.length === 0) {
+            // No authenticated orgs — open a terminal to login
+            const terminal = vscode.window.createTerminal('Salesforce Org Login');
+            terminal.show();
+            terminal.sendText('sf org login web');
+            return;
+        }
+
+        // Show QuickPick to select from existing authenticated orgs
+        const items = orgs.map(org => ({
+            label: org.alias ?? org.username ?? 'Unknown',
+            description: org.username && org.alias ? org.username : undefined,
+            detail: org.defaultMarker ? '(current default)' : undefined,
+            orgAlias: org.alias ?? org.username
+        }));
+
+        const selected = await vscode.window.showQuickPick(items, {
+            placeHolder: messages.insights.selectOrgPlaceholder,
+            title: messages.insights.selectOrgTitle
+        });
+
+        if (selected?.orgAlias) {
+            const result: CommandOutput = await this.cliCommandExecutor.exec('sf', ['config', 'set', `target-org=${selected.orgAlias}`]);
+            if (result.exitCode === 0) {
+                this.display.displayInfo(messages.insights.orgSetSuccess(selected.orgAlias));
+                this.logger.log(`Default target-org set to: ${selected.orgAlias}`);
+            } else {
+                this.display.displayError(messages.insights.orgSetFailure(selected.orgAlias, result.stderr));
+                this.logger.error(`Failed to set target-org: ${result.stderr}`);
+            }
+        }
+    }
+
+    private async listAuthenticatedOrgs(): Promise<OrgInfo[]> {
+        try {
+            const result: CommandOutput = await this.cliCommandExecutor.exec('sf', ['org', 'list', '--json']);
+            if (result.exitCode !== 0) {
+                this.logger.warn(`Failed to list orgs: ${result.stderr}`);
+                return [];
+            }
+
+            const parsed = JSON.parse(result.stdout) as {
+                result?: {
+                    nonScratchOrgs?: Array<{alias?: string; username?: string; isDefaultUsername?: boolean}>;
+                    scratchOrgs?: Array<{alias?: string; username?: string; isDefaultUsername?: boolean}>;
+                }
+            };
+
+            const nonScratch = (parsed.result?.nonScratchOrgs ?? []).map(o => ({
+                alias: o.alias,
+                username: o.username,
+                defaultMarker: o.isDefaultUsername ? '(default)' : undefined
+            }));
+            const scratch = (parsed.result?.scratchOrgs ?? []).map(o => ({
+                alias: o.alias,
+                username: o.username,
+                defaultMarker: o.isDefaultUsername ? '(default)' : undefined
+            }));
+
+            return [...nonScratch, ...scratch];
+        } catch (err) {
+            this.logger.warn(`Error listing orgs: ${err}`);
+            return [];
+        }
     }
 }

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -85,6 +85,23 @@ export const messages = {
         sfMissing: "To use the Salesforce Code Analyzer extension, first install Salesforce CLI.",
         coreExtensionServiceUninitialized: "CoreExtensionService.ts didn't initialize. Log a new issue on Salesforce Code Analyzer VS Code extension repo: https://github.com/forcedotcom/sfdx-code-analyzer-vscode/issues"
     },
+    insights: {
+        apexGuruSkipped: {
+            noOrgConnection: (remediation: string) => `ApexGuru analysis was skipped because no org is connected. ${remediation}`,
+            apiUnavailable: (message: string) => `ApexGuru analysis was skipped because the service is currently unavailable. ${message}`,
+            unexpectedError: (message: string) => `ApexGuru analysis was skipped due to an unexpected error. ${message}`
+        },
+        buttons: {
+            connectOrg: 'Connect Org',
+            retryScan: 'Retry Scan',
+            details: 'Details',
+            viewDetails: 'View Details',
+            reportIssue: 'Report Issue'
+        },
+        fallback: {
+            connectOrgManual: (remediation: string) => `To connect an org manually, run the following in your terminal: ${remediation}`
+        }
+    },
     buttons: {
         learnMore: 'Learn more',
         showError: 'Show error',

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -46,7 +46,10 @@ export const messages = {
     },
     info: {
         scanningWith: (version: string) => `Scanning with code-analyzer@${version} via CLI`,
-        finishedScan: (scannedCount: number, badFileCount: number, violationCount: number) => `Scan complete. Analyzed ${scannedCount} files. ${violationCount} violations found in ${badFileCount} files.`
+        finishedScan: (scannedCount: number, badFileCount: number, violationCount: number, apexGuruAnalysisMode?: string) => {
+            const base = `Scan complete. Analyzed ${scannedCount} files. ${violationCount} violations found in ${badFileCount} files.`;
+            return apexGuruAnalysisMode ? `${base} ApexGuru analysis mode: '${apexGuruAnalysisMode}'.` : base;
+        }
     },
     suggestions: {
         suggestionFor: "Suggestion for",
@@ -98,6 +101,10 @@ export const messages = {
             viewDetails: 'View Details',
             reportIssue: 'Report Issue'
         },
+        selectOrgPlaceholder: 'Select an org to set as the default target-org',
+        selectOrgTitle: 'Connect Salesforce Org',
+        orgSetSuccess: (orgAlias: string) => `Default target-org set to '${orgAlias}'. Re-run the scan to use ApexGuru.`,
+        orgSetFailure: (orgAlias: string, error: string) => `Failed to set target-org to '${orgAlias}': ${error}`,
         fallback: {
             connectOrgManual: (remediation: string) => `To connect an org manually, run the following in your terminal: ${remediation}`
         }

--- a/test/lib/code-analyzer-run-action.test.ts
+++ b/test/lib/code-analyzer-run-action.test.ts
@@ -15,6 +15,16 @@ import {messages} from "../../src/lib/messages";
 import * as Constants from '../../src/lib/constants';
 import {Workspace} from "../../src/lib/workspace";
 import { APEX_GURU_ENGINE_NAME } from "../../src/lib/apexguru/apex-guru-service";
+import {InsightsHandler} from "../../src/lib/insights-handler";
+import {EngineInsight} from "../../src/lib/code-analyzer";
+
+class SpyInsightsHandler {
+    handleInsightsCallHistory: { insights: Record<string, EngineInsight> | undefined, retriggerScan: () => void }[] = [];
+
+    handleInsights(insights: Record<string, EngineInsight> | undefined, retriggerScan: () => void): void {
+        this.handleInsightsCallHistory.push({insights, retriggerScan});
+    }
+}
 
 describe('Tests for CodeAnalyzerRunAction', () => {
     let sampleWorkspace: Workspace;
@@ -26,6 +36,7 @@ describe('Tests for CodeAnalyzerRunAction', () => {
     let logger: SpyLogger;
     let display: SpyDisplay;
     let windowManager: SpyWindowManager;
+    let insightsHandler: SpyInsightsHandler;
     let codeAnalyzerRunAction: CodeAnalyzerRunAction;
 
     beforeEach(async () => {
@@ -41,8 +52,9 @@ describe('Tests for CodeAnalyzerRunAction', () => {
         logger = new SpyLogger();
         display = new SpyDisplay();
         windowManager = new SpyWindowManager();
+        insightsHandler = new SpyInsightsHandler();
         codeAnalyzerRunAction = new CodeAnalyzerRunAction(taskWithProgressRunner, codeAnalyzer, diagnosticManager,
-            diagnosticFactory, telemetryService, logger, display, windowManager);
+            diagnosticFactory, telemetryService, logger, display, windowManager, insightsHandler as unknown as InsightsHandler);
     });
 
     it('When scan results in violations that are not associated with a file location, then show violation as display messages', async () => {
@@ -67,8 +79,8 @@ describe('Tests for CodeAnalyzerRunAction', () => {
             {msg: '[engineE:ruleE] messageE', buttons: []},
         ]);
         expect(display.displayInfoCallHistory).toEqual([
-            {msg: '[engineF:ruleF] messageF'},
-            {msg: 'Scan complete. Analyzed 1 files. 1 violations found in 1 files.'}
+            {msg: '[engineF:ruleF] messageF', buttons: []},
+            {msg: 'Scan complete. Analyzed 1 files. 1 violations found in 1 files.', buttons: []}
         ]);
 
         // Sanity check, good violations still make it
@@ -87,7 +99,7 @@ describe('Tests for CodeAnalyzerRunAction', () => {
         expect(display.displayErrorCallHistory[0].msg).toEqual(messages.error.engineUninstantiable(engine));
         expect(display.displayWarningCallHistory).toEqual([]);
         expect(display.displayInfoCallHistory).toEqual([
-            {msg: 'Scan complete. Analyzed 1 files. 0 violations found in 0 files.'}
+            {msg: 'Scan complete. Analyzed 1 files. 0 violations found in 0 files.', buttons: []}
         ]);
     });
 
@@ -279,6 +291,60 @@ describe('Tests for CodeAnalyzerRunAction', () => {
             expect(telemetryService.sendExceptionCallHistory).toHaveLength(1);
             expect(telemetryService.sendExceptionCallHistory[0].name).toBe(Constants.TELEM_FAILED_STATIC_ANALYSIS);
             expect(telemetryService.sendExceptionCallHistory[0].properties?.trigger).toBe(Constants.TRIGGER_MANUAL);
+        });
+    });
+
+    describe('Insights handling integration', () => {
+        it('When scan returns insights with apexguru skipped, InsightsHandler is invoked', async () => {
+            codeAnalyzer.scanInsightsReturnValue = {
+                apexguru: {
+                    status: 'skipped',
+                    error: {code: 'NO_ORG_CONNECTION', message: 'No org', remediation: 'sf org login web'}
+                }
+            };
+
+            await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+            expect(insightsHandler.handleInsightsCallHistory).toHaveLength(1);
+            expect(insightsHandler.handleInsightsCallHistory[0].insights).toEqual(codeAnalyzer.scanInsightsReturnValue);
+        });
+
+        it('When scan returns insights with apexguru completed, InsightsHandler is still invoked (handler decides)', async () => {
+            codeAnalyzer.scanInsightsReturnValue = {
+                apexguru: {status: 'completed'}
+            };
+
+            await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+            expect(insightsHandler.handleInsightsCallHistory).toHaveLength(1);
+            expect(insightsHandler.handleInsightsCallHistory[0].insights).toEqual(codeAnalyzer.scanInsightsReturnValue);
+        });
+
+        it('When scan returns no insights field (old CLI), InsightsHandler is invoked with undefined', async () => {
+            codeAnalyzer.scanInsightsReturnValue = undefined;
+
+            await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+            expect(insightsHandler.handleInsightsCallHistory).toHaveLength(1);
+            expect(insightsHandler.handleInsightsCallHistory[0].insights).toBeUndefined();
+        });
+
+        it('When apexguru key not present in insights, InsightsHandler is invoked (handler decides)', async () => {
+            codeAnalyzer.scanInsightsReturnValue = {
+                pmd: {status: 'completed'}
+            };
+
+            await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+            expect(insightsHandler.handleInsightsCallHistory).toHaveLength(1);
+            expect(insightsHandler.handleInsightsCallHistory[0].insights).toEqual({pmd: {status: 'completed'}});
+        });
+
+        it('retriggerScan callback is a function that re-invokes the run action', async () => {
+            await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+            expect(insightsHandler.handleInsightsCallHistory).toHaveLength(1);
+            expect(typeof insightsHandler.handleInsightsCallHistory[0].retriggerScan).toBe('function');
         });
     });
 

--- a/test/lib/code-analyzer.test.ts
+++ b/test/lib/code-analyzer.test.ts
@@ -1,4 +1,4 @@
-import {CodeAnalyzer, CodeAnalyzerImpl} from "../../src/lib/code-analyzer";
+import {CodeAnalyzer, CodeAnalyzerImpl, ScanResults} from "../../src/lib/code-analyzer";
 import * as semver from "semver";
 import * as stubs from "../stubs";
 import {messages} from "../../src/lib/messages";
@@ -141,7 +141,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                     ['/my/project/dummyFile1.cls', '/my/project/dummyFile2.cls', '/my/project/subfolder'], vscodeWorkspace, fileHandler);
 
                 // Call scan
-                const violations: Violation[] = await codeAnalyzer.scan(workspace);
+                const scanResults: ScanResults = await codeAnalyzer.scan(workspace);
 
                 // Check that we made the CLI call
                 expect(cliCommandExecutor.execCallHistory.length).toBeGreaterThanOrEqual(1);
@@ -162,7 +162,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                     "-f", prePopulatedResultsJsonFile
                 ]);
 
-                expect(violations).toEqual([expectedViolation1, expectedViolation2]);
+                expect(scanResults.violations).toEqual([expectedViolation1, expectedViolation2]);
             });
 
             it('When running a scan with version 5.12.0, then confirm we call the cli and process the results correctly using both --workspace and --target', async () => {
@@ -175,7 +175,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                 // Call scan
                 const workspace: Workspace = await Workspace.fromTargetPaths(
                     ['/my/project/dummyFile1.cls', '/my/project/dummyFile2.cls'], vscodeWorkspace, fileHandler);
-                const violations: Violation[] = await codeAnalyzer.scan(workspace);
+                const scanResults: ScanResults = await codeAnalyzer.scan(workspace);
 
                 // Check that we made the CLI call
                 expect(cliCommandExecutor.execCallHistory.length).toBeGreaterThanOrEqual(1);
@@ -195,7 +195,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                     "-f", prePopulatedResultsJsonFile
                 ]);
 
-                expect(violations).toEqual([expectedViolation1, expectedViolation2]);
+                expect(scanResults.violations).toEqual([expectedViolation1, expectedViolation2]);
             });
 
             it('When no vscode workspace exist because the user probably just opened a single file, verify the files make up the workspace', async () => {
@@ -209,7 +209,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                 const workspace: Workspace = await Workspace.fromTargetPaths(
                     ['/my/project/dummyFile1.cls', '/my/project/dummyFile2.cls', '/my/project/subfolder'],
                     vscodeWorkspace, fileHandler);
-                const violations: Violation[] = await codeAnalyzer.scan(workspace);
+                const scanResults: ScanResults = await codeAnalyzer.scan(workspace);
 
                 // Check that we made the CLI call
                 expect(cliCommandExecutor.execCallHistory.length).toBeGreaterThanOrEqual(1);
@@ -229,7 +229,7 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                     "-f", prePopulatedResultsJsonFile
                 ]);
 
-                expect(violations).toEqual([expectedViolation1, expectedViolation2]);
+                expect(scanResults.violations).toEqual([expectedViolation1, expectedViolation2]);
             });
 
             it('When scan results contain fixes and suggestions with relative paths, then their locations are made absolute', async () => {
@@ -242,18 +242,18 @@ describe('Tests for the CodeAnalyzerImpl class', () => {
                 const workspace: Workspace = await Workspace.fromTargetPaths(
                     ['/my/project/dummyFile1.js'], vscodeWorkspace, fileHandler);
 
-                const violations: Violation[] = await codeAnalyzer.scan(workspace);
+                const scanResults: ScanResults = await codeAnalyzer.scan(workspace);
 
                 // The first violation should have fixes and suggestions with absolute paths
-                expect(violations[0].fixes).toHaveLength(1);
-                expect(violations[0].fixes[0].location.file).toEqual(path.normalize("/my/project/dummyFile1.js"));
+                expect(scanResults.violations[0].fixes).toHaveLength(1);
+                expect(scanResults.violations[0].fixes[0].location.file).toEqual(path.normalize("/my/project/dummyFile1.js"));
 
-                expect(violations[0].suggestions).toHaveLength(1);
-                expect(violations[0].suggestions[0].location.file).toEqual(path.normalize("/my/project/dummyFile1.js"));
+                expect(scanResults.violations[0].suggestions).toHaveLength(1);
+                expect(scanResults.violations[0].suggestions[0].location.file).toEqual(path.normalize("/my/project/dummyFile1.js"));
 
                 // The second violation should have no fixes or suggestions
-                expect(violations[1].fixes).toBeUndefined();
-                expect(violations[1].suggestions).toBeUndefined();
+                expect(scanResults.violations[1].fixes).toBeUndefined();
+                expect(scanResults.violations[1].suggestions).toBeUndefined();
             });
 
             it('When CLI supports fixes/suggestions flags and settings are enabled, then they are included in scan command', async () => {

--- a/test/lib/insights-handler.integration.test.ts
+++ b/test/lib/insights-handler.integration.test.ts
@@ -18,6 +18,8 @@ import {FakeDiagnosticCollection} from "../vscode-stubs";
 import {ExternalServiceProvider} from "../../src/lib/external-services/external-service-provider";
 import {Workspace} from "../../src/lib/workspace";
 import {messages} from "../../src/lib/messages";
+import {CliCommandExecutor, CommandOutput} from "../../src/lib/cli-commands";
+import * as semver from "semver";
 
 class StubExternalServiceProvider {
     isOrgConnectionServiceAvailableReturnValue: boolean = true;
@@ -25,6 +27,14 @@ class StubExternalServiceProvider {
     async isOrgConnectionServiceAvailable(): Promise<boolean> {
         return this.isOrgConnectionServiceAvailableReturnValue;
     }
+}
+
+class StubCliCommandExecutor implements CliCommandExecutor {
+    execReturnValue: CommandOutput = {stdout: JSON.stringify({result: {nonScratchOrgs: [], scratchOrgs: []}}), stderr: '', exitCode: 0};
+
+    async isSfInstalled(): Promise<boolean> { return true; }
+    async getSfCliPluginVersion(_pluginName: string): Promise<semver.SemVer | undefined> { return undefined; }
+    async exec(_command: string, _args: string[]): Promise<CommandOutput> { return this.execReturnValue; }
 }
 
 describe('InsightsHandler integration tests - full skip-banner lifecycle', () => {
@@ -50,10 +60,12 @@ describe('InsightsHandler integration tests - full skip-banner lifecycle', () =>
         const diagnosticFactory = (diagnosticManager as DiagnosticManagerImpl).diagnosticFactory;
         const telemetryService = new SpyTelemetryService();
 
+        const cliCommandExecutor = new StubCliCommandExecutor();
         const insightsHandler = new InsightsHandler(
             display, logger,
             externalServiceProvider as unknown as ExternalServiceProvider,
-            windowManager
+            windowManager,
+            cliCommandExecutor
         );
 
         codeAnalyzerRunAction = new CodeAnalyzerRunAction(
@@ -80,7 +92,7 @@ describe('InsightsHandler integration tests - full skip-banner lifecycle', () =>
         expect(infoBanners[0].buttons[0].text).toEqual(messages.insights.buttons.connectOrg);
     });
 
-    it('User dismisses banner -> same error code suppressed on next scan', async () => {
+    it('NO_ORG_CONNECTION: User dismisses banner -> suppressed on next scan (non-intrusive)', async () => {
         codeAnalyzer.scanInsightsReturnValue = {
             apexguru: {
                 status: 'skipped',
@@ -92,13 +104,36 @@ describe('InsightsHandler integration tests - full skip-banner lifecycle', () =>
         const firstBannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
         expect(firstBannerCount).toEqual(1);
 
-        // Run scan again - should be suppressed
+        // Run scan again - NO_ORG_CONNECTION should be suppressed
         await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
         const secondBannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
         expect(secondBannerCount).toEqual(1); // Still 1, suppressed
     });
 
-    it('Different error code API_UNAVAILABLE still shows banner after NO_ORG_CONNECTION suppressed', async () => {
+    it('API_UNAVAILABLE: Shows banner every time (transient error, not suppressed)', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'API_UNAVAILABLE', message: 'Service down', remediation: 'Retry'}
+            }
+        };
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        let bannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
+        expect(bannerCount).toEqual(1);
+
+        // Run scan again - API_UNAVAILABLE should show again
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        bannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
+        expect(bannerCount).toEqual(2); // Shows again!
+
+        // And again
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        bannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
+        expect(bannerCount).toEqual(3); // Shows every time
+    });
+
+    it('NO_ORG_CONNECTION suppressed but API_UNAVAILABLE still shows', async () => {
         codeAnalyzer.scanInsightsReturnValue = {
             apexguru: {
                 status: 'skipped',
@@ -120,6 +155,10 @@ describe('InsightsHandler integration tests - full skip-banner lifecycle', () =>
         expect(banners).toHaveLength(2); // Both shown
         expect(banners[0].buttons[0].text).toEqual(messages.insights.buttons.connectOrg);
         expect(banners[1].buttons[0].text).toEqual(messages.insights.buttons.retryScan);
+
+        // API_UNAVAILABLE shows again on next scan
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        expect(display.displayInfoCallHistory.filter(h => h.buttons.length > 0)).toHaveLength(3); // API_UNAVAILABLE not suppressed
     });
 
     it('CLI returns without insights field (older CLI version) -> no crash, no banner, scan completes normally', async () => {

--- a/test/lib/insights-handler.integration.test.ts
+++ b/test/lib/insights-handler.integration.test.ts
@@ -1,0 +1,171 @@
+import * as vscode from "vscode";
+import {InsightsHandler} from "../../src/lib/insights-handler";
+import {CodeAnalyzerRunAction} from "../../src/lib/code-analyzer-run-action";
+import {EngineInsight, ScanResults} from "../../src/lib/code-analyzer";
+import {
+    FakeTaskWithProgressRunner,
+    SpyDisplay,
+    SpyLogger,
+    SpyTelemetryService,
+    SpyWindowManager,
+    StubCodeAnalyzer,
+    StubFileHandler,
+    StubSettingsManager,
+    StubVscodeWorkspace
+} from "../stubs";
+import {DiagnosticManager, DiagnosticManagerImpl} from "../../src/lib/diagnostics";
+import {FakeDiagnosticCollection} from "../vscode-stubs";
+import {ExternalServiceProvider} from "../../src/lib/external-services/external-service-provider";
+import {Workspace} from "../../src/lib/workspace";
+import {messages} from "../../src/lib/messages";
+
+class StubExternalServiceProvider {
+    isOrgConnectionServiceAvailableReturnValue: boolean = true;
+
+    async isOrgConnectionServiceAvailable(): Promise<boolean> {
+        return this.isOrgConnectionServiceAvailableReturnValue;
+    }
+}
+
+describe('InsightsHandler integration tests - full skip-banner lifecycle', () => {
+    let display: SpyDisplay;
+    let logger: SpyLogger;
+    let windowManager: SpyWindowManager;
+    let externalServiceProvider: StubExternalServiceProvider;
+    let codeAnalyzer: StubCodeAnalyzer;
+    let codeAnalyzerRunAction: CodeAnalyzerRunAction;
+    let sampleWorkspace: Workspace;
+
+    beforeEach(async () => {
+        display = new SpyDisplay();
+        logger = new SpyLogger();
+        windowManager = new SpyWindowManager();
+        externalServiceProvider = new StubExternalServiceProvider();
+        codeAnalyzer = new StubCodeAnalyzer();
+
+        const taskWithProgressRunner = new FakeTaskWithProgressRunner();
+        const diagnosticCollection = new FakeDiagnosticCollection();
+        const settingsManager = new StubSettingsManager();
+        const diagnosticManager: DiagnosticManager = new DiagnosticManagerImpl(diagnosticCollection, settingsManager);
+        const diagnosticFactory = (diagnosticManager as DiagnosticManagerImpl).diagnosticFactory;
+        const telemetryService = new SpyTelemetryService();
+
+        const insightsHandler = new InsightsHandler(
+            display, logger,
+            externalServiceProvider as unknown as ExternalServiceProvider,
+            windowManager
+        );
+
+        codeAnalyzerRunAction = new CodeAnalyzerRunAction(
+            taskWithProgressRunner, codeAnalyzer, diagnosticManager,
+            diagnosticFactory, telemetryService, logger, display, windowManager, insightsHandler
+        );
+
+        sampleWorkspace = await Workspace.fromTargetPaths(['someFile.cls'], new StubVscodeWorkspace(), new StubFileHandler());
+    });
+
+    it('CLI returns with insights.apexguru.status=skipped and error.code=NO_ORG_CONNECTION -> info banner appears with Connect Org button', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'NO_ORG_CONNECTION', message: 'No org connected', remediation: 'sf org login web'}
+            }
+        };
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        const infoBanners = display.displayInfoCallHistory.filter(h => h.buttons.length > 0);
+        expect(infoBanners).toHaveLength(1);
+        expect(infoBanners[0].msg).toContain('no org is connected');
+        expect(infoBanners[0].buttons[0].text).toEqual(messages.insights.buttons.connectOrg);
+    });
+
+    it('User dismisses banner -> same error code suppressed on next scan', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'NO_ORG_CONNECTION', message: 'No org', remediation: 'sf org login web'}
+            }
+        };
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        const firstBannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
+        expect(firstBannerCount).toEqual(1);
+
+        // Run scan again - should be suppressed
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+        const secondBannerCount = display.displayInfoCallHistory.filter(h => h.buttons.length > 0).length;
+        expect(secondBannerCount).toEqual(1); // Still 1, suppressed
+    });
+
+    it('Different error code API_UNAVAILABLE still shows banner after NO_ORG_CONNECTION suppressed', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'NO_ORG_CONNECTION', message: 'No org', remediation: 'sf org login web'}
+            }
+        };
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        // Change to API_UNAVAILABLE
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'API_UNAVAILABLE', message: 'Service down', remediation: 'Retry'}
+            }
+        };
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        const banners = display.displayInfoCallHistory.filter(h => h.buttons.length > 0);
+        expect(banners).toHaveLength(2); // Both shown
+        expect(banners[0].buttons[0].text).toEqual(messages.insights.buttons.connectOrg);
+        expect(banners[1].buttons[0].text).toEqual(messages.insights.buttons.retryScan);
+    });
+
+    it('CLI returns without insights field (older CLI version) -> no crash, no banner, scan completes normally', async () => {
+        codeAnalyzer.scanInsightsReturnValue = undefined;
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        const banners = display.displayInfoCallHistory.filter(h => h.buttons.length > 0);
+        expect(banners).toHaveLength(0);
+        // Scan completed normally - displayed results info
+        expect(display.displayInfoCallHistory.some(h => h.msg.includes('Scan complete'))).toBe(true);
+    });
+
+    it('CLI returns with insights.apexguru.status=completed -> no banner', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {status: 'completed'}
+        };
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        const banners = display.displayInfoCallHistory.filter(h => h.buttons.length > 0);
+        expect(banners).toHaveLength(0);
+    });
+
+    it('User clicks Retry Scan -> scan re-triggers', async () => {
+        codeAnalyzer.scanInsightsReturnValue = {
+            apexguru: {
+                status: 'skipped',
+                error: {code: 'API_UNAVAILABLE', message: 'Service down', remediation: 'Retry'}
+            }
+        };
+
+        await codeAnalyzerRunAction.run('dummyCommandName', sampleWorkspace);
+
+        const banners = display.displayInfoCallHistory.filter(h => h.buttons.length > 0);
+        expect(banners).toHaveLength(1);
+
+        // Clear insights for next scan so we can detect it happened
+        codeAnalyzer.scanInsightsReturnValue = undefined;
+
+        // Click Retry Scan - the callback fires and forgets; give it a tick to complete
+        banners[0].buttons[0].callback();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Verify scan ran again (displayed results again)
+        const scanCompleteMsgs = display.displayInfoCallHistory.filter(h => h.msg.includes('Scan complete'));
+        expect(scanCompleteMsgs.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/test/lib/insights-handler.test.ts
+++ b/test/lib/insights-handler.test.ts
@@ -4,6 +4,8 @@ import {EngineInsight} from "../../src/lib/code-analyzer";
 import {SpyDisplay, SpyLogger, SpyWindowManager} from "../stubs";
 import {messages} from "../../src/lib/messages";
 import {ExternalServiceProvider} from "../../src/lib/external-services/external-service-provider";
+import {CliCommandExecutor, CommandOutput} from "../../src/lib/cli-commands";
+import * as semver from "semver";
 
 class StubExternalServiceProvider {
     isOrgConnectionServiceAvailableReturnValue: boolean = true;
@@ -13,11 +15,30 @@ class StubExternalServiceProvider {
     }
 }
 
+class StubCliCommandExecutor implements CliCommandExecutor {
+    execHistory: {command: string; args: string[]}[] = [];
+    execReturnValue: CommandOutput = {stdout: '', stderr: '', exitCode: 0};
+
+    async isSfInstalled(): Promise<boolean> {
+        return true;
+    }
+
+    async getSfCliPluginVersion(_pluginName: string): Promise<semver.SemVer | undefined> {
+        return undefined;
+    }
+
+    async exec(command: string, args: string[]): Promise<CommandOutput> {
+        this.execHistory.push({command, args});
+        return this.execReturnValue;
+    }
+}
+
 describe('Tests for InsightsHandler', () => {
     let display: SpyDisplay;
     let logger: SpyLogger;
     let externalServiceProvider: StubExternalServiceProvider;
     let windowManager: SpyWindowManager;
+    let cliCommandExecutor: StubCliCommandExecutor;
     let insightsHandler: InsightsHandler;
     let retriggerScanCallCount: number;
     let retriggerScan: () => void;
@@ -27,10 +48,12 @@ describe('Tests for InsightsHandler', () => {
         logger = new SpyLogger();
         externalServiceProvider = new StubExternalServiceProvider();
         windowManager = new SpyWindowManager();
+        cliCommandExecutor = new StubCliCommandExecutor();
         insightsHandler = new InsightsHandler(
             display, logger,
             externalServiceProvider as unknown as ExternalServiceProvider,
-            windowManager
+            windowManager,
+            cliCommandExecutor
         );
         retriggerScanCallCount = 0;
         retriggerScan = () => { retriggerScanCallCount++; };
@@ -119,7 +142,7 @@ describe('Tests for InsightsHandler', () => {
         expect(display.displayInfoCallHistory[0].buttons[1].text).toEqual(messages.insights.buttons.reportIssue);
     });
 
-    it('After a banner is shown for an error code, the same code does not produce a banner again (session suppression)', () => {
+    it('NO_ORG_CONNECTION is shown once per session (non-intrusive)', () => {
         const insights: Record<string, EngineInsight> = {
             apexguru: {
                 status: 'skipped',
@@ -138,7 +161,51 @@ describe('Tests for InsightsHandler', () => {
         expect(display.displayInfoCallHistory).toHaveLength(1); // Still 1, suppressed
     });
 
-    it('Different error codes are suppressed independently', () => {
+    it('API_UNAVAILABLE is shown every time (transient error)', () => {
+        const apiInsights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'API_UNAVAILABLE',
+                    message: 'Service down',
+                    remediation: 'Retry later'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(apiInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+
+        // API_UNAVAILABLE shows again (not suppressed)
+        insightsHandler.handleInsights(apiInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(2);
+
+        // And again
+        insightsHandler.handleInsights(apiInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(3);
+    });
+
+    it('UNEXPECTED_ERROR is shown every time', () => {
+        const unexpectedInsights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'UNEXPECTED_ERROR',
+                    message: 'Something went wrong',
+                    remediation: 'Check logs'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(unexpectedInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+
+        // UNEXPECTED_ERROR shows again (not suppressed)
+        insightsHandler.handleInsights(unexpectedInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(2);
+    });
+
+    it('NO_ORG_CONNECTION suppression does not affect other error codes', () => {
         const noOrgInsights: Record<string, EngineInsight> = {
             apexguru: {
                 status: 'skipped',
@@ -160,20 +227,33 @@ describe('Tests for InsightsHandler', () => {
             }
         };
 
+        // Show NO_ORG_CONNECTION once
         insightsHandler.handleInsights(noOrgInsights, retriggerScan);
         expect(display.displayInfoCallHistory).toHaveLength(1);
 
-        // Same code suppressed
+        // NO_ORG_CONNECTION suppressed
         insightsHandler.handleInsights(noOrgInsights, retriggerScan);
         expect(display.displayInfoCallHistory).toHaveLength(1);
 
-        // Different code still shows
+        // API_UNAVAILABLE still shows
         insightsHandler.handleInsights(apiInsights, retriggerScan);
         expect(display.displayInfoCallHistory).toHaveLength(2);
+
+        // API_UNAVAILABLE shows again
+        insightsHandler.handleInsights(apiInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(3);
     });
 
-    it('Connect Org button triggers vscode.commands.executeCommand when Core Extension is available', async () => {
-        externalServiceProvider.isOrgConnectionServiceAvailableReturnValue = true;
+    it('Connect Org button opens terminal with sf org login web when no orgs are authenticated', async () => {
+        // sf org list returns no orgs
+        cliCommandExecutor.execReturnValue = {
+            stdout: JSON.stringify({result: {nonScratchOrgs: [], scratchOrgs: []}}),
+            stderr: '',
+            exitCode: 0
+        };
+
+        const mockTerminal = {show: jest.fn(), sendText: jest.fn()};
+        (vscode.window.createTerminal as jest.Mock).mockReturnValue(mockTerminal);
 
         const insights: Record<string, EngineInsight> = {
             apexguru: {
@@ -192,11 +272,25 @@ describe('Tests for InsightsHandler', () => {
         // Allow the async promise to resolve
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('sfdx.authorize.org');
+        expect(vscode.window.createTerminal).toHaveBeenCalledWith('Salesforce Org Login');
+        expect(mockTerminal.show).toHaveBeenCalled();
+        expect(mockTerminal.sendText).toHaveBeenCalledWith('sf org login web');
     });
 
-    it('Connect Org button shows fallback message when Core Extension is NOT available', async () => {
-        externalServiceProvider.isOrgConnectionServiceAvailableReturnValue = false;
+    it('Connect Org button shows QuickPick when orgs are already authenticated', async () => {
+        // sf org list returns some orgs
+        cliCommandExecutor.execReturnValue = {
+            stdout: JSON.stringify({
+                result: {
+                    nonScratchOrgs: [
+                        {alias: 'myOrg', username: 'user@example.com', isDefaultUsername: false}
+                    ],
+                    scratchOrgs: []
+                }
+            }),
+            stderr: '',
+            exitCode: 0
+        };
 
         const insights: Record<string, EngineInsight> = {
             apexguru: {
@@ -215,8 +309,54 @@ describe('Tests for InsightsHandler', () => {
         // Allow the async promise to resolve
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        expect(display.displayInfoCallHistory).toHaveLength(2);
-        expect(display.displayInfoCallHistory[1].msg).toContain('sf org login web');
+        expect(vscode.window.showQuickPick).toHaveBeenCalled();
+    });
+
+    it('Connect Org button sets target-org when user selects an org from QuickPick', async () => {
+        // sf org list returns some orgs
+        cliCommandExecutor.execReturnValue = {
+            stdout: JSON.stringify({
+                result: {
+                    nonScratchOrgs: [
+                        {alias: 'myOrg', username: 'user@example.com', isDefaultUsername: false}
+                    ],
+                    scratchOrgs: []
+                }
+            }),
+            stderr: '',
+            exitCode: 0
+        };
+
+        // Mock showQuickPick to simulate user selection
+        (vscode.window.showQuickPick as jest.Mock).mockResolvedValueOnce({
+            label: 'myOrg',
+            description: 'user@example.com',
+            orgAlias: 'myOrg'
+        });
+
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[0].callback();
+
+        // Allow the async promises to resolve
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Verify sf config set was called
+        const configSetCall = cliCommandExecutor.execHistory.find(
+            call => call.args.includes('config') && call.args.includes('set')
+        );
+        expect(configSetCall).toBeDefined();
+        expect(configSetCall.args).toContain('target-org=myOrg');
     });
 
     it('Retry Scan button re-triggers the scan', () => {
@@ -253,6 +393,16 @@ describe('Tests for InsightsHandler', () => {
         display.displayInfoCallHistory[0].buttons[0].callback();
 
         expect(windowManager.showLogOutputWindowCallCount).toEqual(1);
+    });
+
+    it('When apexguru insight has analysisMode without a skip error, then handler shows no banner (analysis mode is embedded in scan-complete message elsewhere)', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {status: 'completed', analysisMode: 'full'}
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+
+        expect(display.displayInfoCallHistory).toHaveLength(0);
     });
 
     it('Report Issue button opens issues URL', () => {

--- a/test/lib/insights-handler.test.ts
+++ b/test/lib/insights-handler.test.ts
@@ -1,0 +1,276 @@
+import * as vscode from "vscode";
+import {InsightsHandler} from "../../src/lib/insights-handler";
+import {EngineInsight} from "../../src/lib/code-analyzer";
+import {SpyDisplay, SpyLogger, SpyWindowManager} from "../stubs";
+import {messages} from "../../src/lib/messages";
+import {ExternalServiceProvider} from "../../src/lib/external-services/external-service-provider";
+
+class StubExternalServiceProvider {
+    isOrgConnectionServiceAvailableReturnValue: boolean = true;
+
+    async isOrgConnectionServiceAvailable(): Promise<boolean> {
+        return this.isOrgConnectionServiceAvailableReturnValue;
+    }
+}
+
+describe('Tests for InsightsHandler', () => {
+    let display: SpyDisplay;
+    let logger: SpyLogger;
+    let externalServiceProvider: StubExternalServiceProvider;
+    let windowManager: SpyWindowManager;
+    let insightsHandler: InsightsHandler;
+    let retriggerScanCallCount: number;
+    let retriggerScan: () => void;
+
+    beforeEach(() => {
+        display = new SpyDisplay();
+        logger = new SpyLogger();
+        externalServiceProvider = new StubExternalServiceProvider();
+        windowManager = new SpyWindowManager();
+        insightsHandler = new InsightsHandler(
+            display, logger,
+            externalServiceProvider as unknown as ExternalServiceProvider,
+            windowManager
+        );
+        retriggerScanCallCount = 0;
+        retriggerScan = () => { retriggerScanCallCount++; };
+    });
+
+    it('When insights is undefined, then no banner is shown', () => {
+        insightsHandler.handleInsights(undefined, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(0);
+    });
+
+    it('When insights has no apexguru key, then no banner is shown', () => {
+        const insights: Record<string, EngineInsight> = {
+            pmd: {status: 'completed'}
+        };
+        insightsHandler.handleInsights(insights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(0);
+    });
+
+    it('When apexguru status is completed, then no banner is shown', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {status: 'completed'}
+        };
+        insightsHandler.handleInsights(insights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(0);
+    });
+
+    it('When apexguru status is skipped with NO_ORG_CONNECTION, then info banner is shown with Connect Org button', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org connected',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+        expect(display.displayInfoCallHistory[0].msg).toContain('no org is connected');
+        expect(display.displayInfoCallHistory[0].buttons).toHaveLength(1);
+        expect(display.displayInfoCallHistory[0].buttons[0].text).toEqual(messages.insights.buttons.connectOrg);
+    });
+
+    it('When apexguru status is skipped with API_UNAVAILABLE, then info banner is shown with Retry Scan and Details buttons', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'API_UNAVAILABLE',
+                    message: 'Service temporarily down',
+                    remediation: 'Try again later'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+        expect(display.displayInfoCallHistory[0].msg).toContain('service is currently unavailable');
+        expect(display.displayInfoCallHistory[0].buttons).toHaveLength(2);
+        expect(display.displayInfoCallHistory[0].buttons[0].text).toEqual(messages.insights.buttons.retryScan);
+        expect(display.displayInfoCallHistory[0].buttons[1].text).toEqual(messages.insights.buttons.details);
+    });
+
+    it('When apexguru status is skipped with UNEXPECTED_ERROR, then info banner is shown with View Details and Report Issue buttons', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'UNEXPECTED_ERROR',
+                    message: 'Something went wrong',
+                    remediation: 'Contact support'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+        expect(display.displayInfoCallHistory[0].msg).toContain('unexpected error');
+        expect(display.displayInfoCallHistory[0].buttons).toHaveLength(2);
+        expect(display.displayInfoCallHistory[0].buttons[0].text).toEqual(messages.insights.buttons.viewDetails);
+        expect(display.displayInfoCallHistory[0].buttons[1].text).toEqual(messages.insights.buttons.reportIssue);
+    });
+
+    it('After a banner is shown for an error code, the same code does not produce a banner again (session suppression)', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org connected',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1); // Still 1, suppressed
+    });
+
+    it('Different error codes are suppressed independently', () => {
+        const noOrgInsights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+        const apiInsights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'API_UNAVAILABLE',
+                    message: 'Service down',
+                    remediation: 'Retry later'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(noOrgInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+
+        // Same code suppressed
+        insightsHandler.handleInsights(noOrgInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(1);
+
+        // Different code still shows
+        insightsHandler.handleInsights(apiInsights, retriggerScan);
+        expect(display.displayInfoCallHistory).toHaveLength(2);
+    });
+
+    it('Connect Org button triggers vscode.commands.executeCommand when Core Extension is available', async () => {
+        externalServiceProvider.isOrgConnectionServiceAvailableReturnValue = true;
+
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[0].callback();
+
+        // Allow the async promise to resolve
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('sfdx.authorize.org');
+    });
+
+    it('Connect Org button shows fallback message when Core Extension is NOT available', async () => {
+        externalServiceProvider.isOrgConnectionServiceAvailableReturnValue = false;
+
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'NO_ORG_CONNECTION',
+                    message: 'No org',
+                    remediation: 'sf org login web'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[0].callback();
+
+        // Allow the async promise to resolve
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(display.displayInfoCallHistory).toHaveLength(2);
+        expect(display.displayInfoCallHistory[1].msg).toContain('sf org login web');
+    });
+
+    it('Retry Scan button re-triggers the scan', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'API_UNAVAILABLE',
+                    message: 'Service down',
+                    remediation: 'Retry later'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[0].callback();
+
+        expect(retriggerScanCallCount).toEqual(1);
+    });
+
+    it('View Details button shows log output window', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'UNEXPECTED_ERROR',
+                    message: 'Something went wrong',
+                    remediation: 'Contact support'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[0].callback();
+
+        expect(windowManager.showLogOutputWindowCallCount).toEqual(1);
+    });
+
+    it('Report Issue button opens issues URL', () => {
+        const insights: Record<string, EngineInsight> = {
+            apexguru: {
+                status: 'skipped',
+                error: {
+                    code: 'UNEXPECTED_ERROR',
+                    message: 'Something went wrong',
+                    remediation: 'Contact support'
+                }
+            }
+        };
+
+        insightsHandler.handleInsights(insights, retriggerScan);
+        display.displayInfoCallHistory[0].buttons[1].callback();
+
+        expect(windowManager.showExternalUrlCallHistory).toHaveLength(1);
+        expect(windowManager.showExternalUrlCallHistory[0].url).toContain('github.com/forcedotcom/sfdx-code-analyzer-vscode/issues');
+    });
+});

--- a/test/lib/messages.test.ts
+++ b/test/lib/messages.test.ts
@@ -1,0 +1,37 @@
+import {messages} from "../../src/lib/messages";
+
+describe('Tests for messages', () => {
+    describe('insights messages', () => {
+        it('apexGuruSkipped.noOrgConnection produces expected output', () => {
+            const result = messages.insights.apexGuruSkipped.noOrgConnection('Run sf org login web');
+            expect(result).toContain('no org is connected');
+            expect(result).toContain('Run sf org login web');
+        });
+
+        it('apexGuruSkipped.apiUnavailable produces expected output', () => {
+            const result = messages.insights.apexGuruSkipped.apiUnavailable('Service is down');
+            expect(result).toContain('service is currently unavailable');
+            expect(result).toContain('Service is down');
+        });
+
+        it('apexGuruSkipped.unexpectedError produces expected output', () => {
+            const result = messages.insights.apexGuruSkipped.unexpectedError('Something went wrong');
+            expect(result).toContain('unexpected error');
+            expect(result).toContain('Something went wrong');
+        });
+
+        it('buttons contain expected labels', () => {
+            expect(messages.insights.buttons.connectOrg).toEqual('Connect Org');
+            expect(messages.insights.buttons.retryScan).toEqual('Retry Scan');
+            expect(messages.insights.buttons.details).toEqual('Details');
+            expect(messages.insights.buttons.viewDetails).toEqual('View Details');
+            expect(messages.insights.buttons.reportIssue).toEqual('Report Issue');
+        });
+
+        it('fallback.connectOrgManual produces expected output', () => {
+            const result = messages.insights.fallback.connectOrgManual('sf org login web');
+            expect(result).toContain('sf org login web');
+            expect(result).toContain('run the following in your terminal');
+        });
+    });
+});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -5,6 +5,7 @@ import {Logger} from "../src/lib/logger";
 import {LLMService, LLMServiceProvider} from "../src/lib/external-services/llm-service";
 import {Violation} from "../src/lib/diagnostics";
 import {Display, DisplayButton} from "../src/lib/display";
+import {ScanResults, EngineInsight} from "../src/lib/code-analyzer";
 import {UnifiedDiffService} from "../src/lib/unified-diff-service";
 import {TextDocument} from "vscode";
 import {SettingsManager} from "../src/lib/settings";
@@ -77,10 +78,10 @@ export class SpyLogger implements Logger {
 }
 
 export class SpyDisplay implements Display {
-    displayInfoCallHistory: { msg: string }[] = [];
+    displayInfoCallHistory: { msg: string, buttons: DisplayButton[] }[] = [];
 
-    displayInfo(msg: string): void {
-        this.displayInfoCallHistory.push({msg});
+    displayInfo(msg: string, ...buttons: DisplayButton[]): void {
+        this.displayInfoCallHistory.push({msg, buttons});
     }
 
     displayWarningCallHistory: { msg: string, buttons: DisplayButton[] }[] = [];
@@ -147,9 +148,13 @@ export class StubCodeAnalyzer implements CodeAnalyzer {
     }
 
     scanReturnValue: Violation[] = [];
+    scanInsightsReturnValue: Record<string, EngineInsight> | undefined = undefined;
 
-    scan(_workspace: Workspace): Promise<Violation[]> {
-        return Promise.resolve(this.scanReturnValue);
+    scan(_workspace: Workspace): Promise<ScanResults> {
+        return Promise.resolve({
+            violations: this.scanReturnValue,
+            insights: this.scanInsightsReturnValue
+        });
     }
 
     getScannerNameReturnValue: string = 'dummyScannerName';
@@ -170,7 +175,7 @@ export class ThrowingCodeAnalyzer implements CodeAnalyzer {
         throw new Error("Error from validateEnvironment");
     }
 
-    scan(_workspace: Workspace): Promise<Violation[]> {
+    scan(_workspace: Workspace): Promise<ScanResults> {
         throw new Error("Error from scan");
     }
 


### PR DESCRIPTION
## Summary
When a user is not logged in to a Salesforce org, the ApexGuru engine is skipped gracefully, and a non-blocking "Connect Org" banner is displayed to guide the user to authenticate.

## GUS Ticket W-22393677 — User Not Logged In — Skip ApexGuru, Show Non-Blocking "Connect Org" Banner

## Changes
- Add InsightsHandler to gracefully handle undefined insights when ApexGuru is skipped due to missing authentication
- Wire InsightsHandler into CodeAnalyzerRunAction.run() flow at line 115
- Update ResultsJson type to support optional insights field for backward compatibility
- Display non-blocking banner when SFAP authentication is not configured

## Dependencies
- https://github.com/forcedotcom/code-analyzer-core/pull/478

## Test Evidence
Unit tests: 362/362 pass (24 suites, 97.19% coverage). Integration baseline: dreamhouse scan 637 violations, no crash, CLI exit 0. Feature-specific: CLI correctly omits insights when SFAP not configured (AG engine returns 0 rules, graceful skip). VS Code extension handles undefined insights via optional field in ResultsJson type - backward compat confirmed by unit tests. InsightsHandler correctly wired into CodeAnalyzerRunAction.run() flow at line 115. No fixes needed.

## Test Status
PASS

Fix attempts: 0

Integration: PASS - baseline scan succeeds (637 violations), CLI does not crash with AG absent, extension compiles and all unit tests pass with mocked insights scenarios covering all error codes

Known external failures (not blocking): ApexGuru engine disabled in test env (SFAP API base URL not configured) - cannot produce live insights output