### PR TITLE
NEW @W-22462047@ add gus info

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Salesforce Code Analyzer,Salesforce Code Analyzer


### PR DESCRIPTION
Adds the required `#GUSINFO:` line to `CODEOWNERS` per the OSPO compliance request (FY27 V2MOM). Mirrors forcedotcom/code-analyzer-core#485.