### PR TITLE
FIX @W-22462052@ Bump @vscode/test-electron to 3.1.0 to fix e2e smoke-test failure on VS Code 1.131.0

### DIFF
--- a/end-to-end/package-lock.json
+++ b/end-to-end/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/mocha": "^10.0.10",
                 "@types/vscode": "^1.125.0",
                 "@vscode/test-cli": "^0.0.15",
-                "@vscode/test-electron": "^2.5.2",
+                "@vscode/test-electron": "^3.1.0",
                 "chai": "^6.2.2"
             },
             "engines": {
@@ -378,9 +378,9 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -391,7 +391,7 @@
                 "semver": "^7.6.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=22"
             }
         },
         "node_modules/agent-base": {

--- a/end-to-end/package.json
+++ b/end-to-end/package.json
@@ -7,7 +7,7 @@
         "@types/mocha": "^10.0.10",
         "@types/vscode": "^1.125.0",
         "@vscode/test-cli": "^0.0.15",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "chai": "^6.2.2"
     },
     "engines": {


### PR DESCRIPTION
## What & why

The `daily-smoke-test` started failing on `macos-latest` beginning **2026-07-30**. All three retry attempts failed identically. Unit tests pass (367/367); the failure is in the **end-to-end** step:

```
Test error: Error: spawn .../vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Exit code: -2
```

### Root cause

The e2e config (`end-to-end/.vscode-test.mjs`) does not pin a VS Code version, so `@vscode/test-cli` downloads the latest **stable**. VS Code was bumped from **1.130.0** (last green run, 07-29) to **1.131.0** (07-30). In 1.131.0 the macOS app-bundle executable was renamed from `Electron` to `Code`:

```
$ ls "vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/"
Code
```

`@vscode/test-electron@2.5.2` still spawns `.../Contents/MacOS/Electron`, which no longer exists → `ENOENT`. Retries can't help because every run re-downloads the same 1.131.0.

## Fix

Bump `@vscode/test-electron` `^2.5.2` → `^3.1.0` in `end-to-end/package.json` (3.x resolves the renamed macOS binary). Lock file regenerated.

Note: `@vscode/test-electron@3.x` requires Node >= 22; CI uses `node-version: lts/*` (>= 22), so this is satisfied.

## Verification

Ran the e2e suite locally against the exact failing version (VS Code **1.131.0**, darwin-arm64):

```
E2E Extension tests
  ✔ Extension should be activated ...
  ✔ ... sfca.runOnActiveFile adds/clears diagnostics (13745ms)
  ✔ ... sfca.runOnSelected adds/clears diagnostics (3641ms)
3 passing (17s)
Exit code: 0
```